### PR TITLE
Fix bug where rdtActive not getting set

### DIFF
--- a/src/DaysView.js
+++ b/src/DaysView.js
@@ -77,7 +77,7 @@ var DateTimePickerDays = React.createClass({
 			else if( ( prevMonth.year() == currentYear && prevMonth.month() > currentMonth ) || ( prevMonth.year() > currentYear ) )
 				classes += ' rdtNew';
 
-			if( selected && prevMonth.isSame( {y: selected.year(), M: selected.month(), d: selected.date()} ) )
+			if( selected && prevMonth.isSame(selected, 'day') )
 				classes += ' rdtActive';
 
 			if (prevMonth.isSame(moment(), 'day') )


### PR DESCRIPTION
We noticed that rdtActive was not getting set at all. That's because isSame is being called incorrectly for Moment v2+.

The equivalent functionality is to pass a moment as the first argument and the string "day" as the second argument:

"When including a second parameter, it will match all units equal or larger. Passing in month will check month and year. Passing in day will check day, month, and year."
http://momentjs.com/docs/#/query/is-same/