### PR TITLE
Months selectors is empty if not english locale.

### DIFF
--- a/src/MonthsView.js
+++ b/src/MonthsView.js
@@ -54,7 +54,7 @@ var DateTimePickerMonths = React.createClass({
 	},
 
 	renderMonth: function( props, month, year, selectedDate ) {
-		return DOM.td( props, this.props.viewDate.localeData()._monthsShort[ month ] );
+		return DOM.td( props, (moment.monthsShort())[ month ] );
 	}
 });
 


### PR DESCRIPTION
I tried to use Your datapicker on my page, where moment is swiched to russian location.
When i click year line, all month choosers was empty. This fix for my problem, maybe its will be helpfull for you.

Thanks for datapicker.