### PR TITLE
Hover styles for Days

### DIFF
--- a/css/react-datetime.css
+++ b/css/react-datetime.css
@@ -37,7 +37,7 @@
   text-align: center;
   height: 28px;
 }
-.rdtPicker td.rdtToday:hover,
+.rdtPicker td.rdtDay:hover,
 .rdtPicker td.rdtHour:hover,
 .rdtPicker td.rdtMinute:hover,
 .rdtPicker td.rdtSecond:hover,


### PR DESCRIPTION
This change fixes a minor styling issue: only _today's_ date has the expected `:hover` styles, caused by what I assume was just a simple typo.

Cheers :beers:

For those looking for a workaround, add this to your CSS:

```css
.rdtPicker td.rdtDay:hover {
  background: #eeeeee;
  cursor: pointer;
}
```