### PR TITLE
Add storybook and some stories

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,0 +1,7 @@
+import { configure } from '@kadira/storybook';
+
+function loadStories() {
+  require('../stories/stories');
+}
+
+configure(loadStories, module);

--- a/.storybook/head.html
+++ b/.storybook/head.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" type="text/css" href="/react-datetime.css">

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "build": "./node_modules/.bin/gulp.cmd",
     "test": "node node_modules/mocha/bin/mocha tests",
-    "dev": "webpack-dev-server --config example/webpack.config.js --devtool eval --progress --colors --hot --content-base example"
+    "dev": "webpack-dev-server --config example/webpack.config.js --devtool eval --progress --colors --hot --content-base example",
+    "storybook": "start-storybook -p 9001 -s ./css",
+    "build-storybook": "build-storybook -o /tmp/storybook -s ./css"
   },
   "keywords": [
     "react",
@@ -42,6 +44,7 @@
     "webpack-dev-server": "^1.7.0"
   },
   "dependencies": {
+    "@kadira/storybook": "^1.28.1",
     "object-assign": "^3.0.0",
     "react-onclickoutside": "^4.1.0"
   }

--- a/stories/stories.js
+++ b/stories/stories.js
@@ -1,0 +1,46 @@
+var React = require('react');
+var storybook = require('@kadira/storybook');
+var Datetime = require('../DateTime.js');
+
+storybook.storiesOf('DateTime', module)
+  .add('default', function () {
+    return <Datetime />
+  })
+  .add('with default value', function () {
+    return <Datetime defaultValue={ new Date(1970, 0, 1) }/>
+  })
+  .add('without input', function () {
+    return <Datetime input={ false }/>
+  })
+  .add('openned', function () {
+    return <Datetime open={ true }/>
+  })
+
+storybook.storiesOf('DateTime.viewMode', module)
+  .add('time', function () {
+    return <Datetime viewMode='time'/>
+  })
+  .add('days', function () {
+    return <Datetime viewMode='days'/>
+  })
+  .add('months', function () {
+    return <Datetime viewMode='months'/>
+  })
+  .add('years', function () {
+    return <Datetime viewMode='years'/>
+  })
+
+storybook.storiesOf('DateTime.isValidDate', module)
+  .add('disabled before today', function () {
+    var yesterday = Datetime.moment().subtract(1, 'day');
+    var valid = function( current ){
+        return current.isAfter( yesterday );
+    };
+    return <Datetime isValidDate={ valid } />
+  })
+  .add('disabled weekends', function () {
+    var valid = function( current ){
+        return current.day() != 0 && current.day() != 6;
+    };
+    return <Datetime isValidDate={ valid } />
+  })


### PR DESCRIPTION
We've built [react storybook](https://github.com/kadirahq/react-storybook) and its getting a lot of attention. This adds storybook to react-datetime.

Storybook can be used to demonstrate the behavior of react components or as a development tool while writing a component. 

I pushed some static built stories for react-datetime to github pages. [Check them out](http://roonyh.github.io/react-datetime/).

[Read more](https://voice.kadira.io/introducing-react-storybook-ec27f28de1e2#.ey9w5kp8q) if you are interested :)
