### PR TITLE
Fix 12 hour time clock to display correct 12AM /12PM in the picker.

### DIFF
--- a/src/TimeView.js
+++ b/src/TimeView.js
@@ -25,7 +25,7 @@ var DateTimePickerTime = React.createClass({
 
 		var daypart = false;
 		if( this.props.timeFormat.indexOf(' A') != -1  && this.state != null ){
-			daypart = ( this.state.hours > 12 ) ? 'PM' : 'AM';
+			daypart = ( this.state.hours >= 12 ) ? 'PM' : 'AM';
 		}
 
 		return {
@@ -41,7 +41,12 @@ var DateTimePickerTime = React.createClass({
 		if (type !== 'daypart') {
 			var value = this.state[ type ];
 			if (type === 'hours' && this.props.timeFormat.indexOf(' A') != -1 && value > 12) {
-				value = value - 12;
+				if(value > 12){
+					value = value - 12;
+				}
+				if(value == 0) {
+					value = 12;
+				}
 			}
 			return DOM.div({ key: type, className: 'rdtCounter'}, [
 				DOM.span({ key:'up', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'increase', type ) }, '▲' ),


### PR DESCRIPTION
When using the timeFormat for the 12 hour clock, 12PM was displayed as 12AM, and 12AM was displayed as 0:00. This pull request fixes that issue. 

```
<DateTime
  value={this.props.endTime}
  dateFormat={false}
  timeFormat="h:mm A"
/>
```