### PR TITLE
Add pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,6 @@ Contributions
 ===============================
 Any help is always welcome :)
 
-**Please use the linter before submitting your pull request.**
-
-```
-npm run lint
-```
-
 ### [Changelog](CHANGELOG.md)
 
 ### [MIT Licensed](LICENSE)

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jsdom": "^7.0.2",
     "mocha": "^2.2.5",
     "moment": "2.14.1",
+    "pre-commit": "^1.1.3",
     "react": ">=0.13",
     "react-addons-test-utils": ">=0.13",
     "react-dom": "15.2.1",
@@ -50,5 +51,9 @@
   "dependencies": {
     "object-assign": "^3.0.0",
     "react-onclickoutside": "^4.1.0"
-  }
+  },
+  "pre-commit": [
+    "lint",
+    "test"
+  ]
 }


### PR DESCRIPTION
Referencing issue #108.

I decided for a pre-commit over a pre-push, as I think it's better to see your errors while performing your commits instead of a bunch of problems when pushing. 

The pre-commit hook will run the `lint` and the `test` tasks. If any of them fail the commit will not be accepted. You can disable the hook for the current commit by using `--no-verify` on your commit, e.g. `git commit -m 'Commit message' --no-verify`. This should only be used for commits that break any test but is fixed with a later commit in the same push (if that makes sense :) ).

**Be sure to run `npm install` to get the [`pre-commit`](https://github.com/observing/pre-commit) package.**