### PR TITLE
Add test task with watch option

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:win": "./node_modules/.bin/gulp.cmd",
     "build:mac": "./node_modules/.bin/gulp",
     "test": "node node_modules/mocha/bin/mocha tests",
+    "test:watch": "node node_modules/mocha/bin/mocha --watch tests",
     "dev": "webpack-dev-server --config example/webpack.config.js --devtool eval --progress --colors --hot --content-base example",
     "lint": "./node_modules/.bin/eslint src/ DateTime.js"
   },


### PR DESCRIPTION
Writing tests often requires them to be run multiple times before they pass. It can be a hassle switching focus back and forth between your editor/IDE (to write code) and terminal (to init test task). By running this npm task the mocha instance will watch for changes in files and automatically re-run the test task, saving you time and energy.

It is run like `npm run test:watch`.