### PR TITLE
Fix for invalid moment object as input value

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -73,7 +73,7 @@ var Datetime = React.createClass({
 	getStateFromProps: function( props ){
 		var formats = this.getFormats( props ),
 			date = props.value || props.defaultValue,
-			selectedDate, viewDate, updateOn
+			selectedDate, viewDate, updateOn, inputValue
 		;
 
 		if ( date && typeof date === 'string' )
@@ -91,12 +91,19 @@ var Datetime = React.createClass({
 
 		updateOn = this.getUpdateOn(formats);
 
+		if ( selectedDate )
+			inputValue = selectedDate.format(formats.datetime);
+		else if ( date.isValid && !date.isValid() )
+			inputValue = '';
+		else
+			inputValue = date || '';
+
 		return {
 			updateOn: updateOn,
 			inputFormat: formats.datetime,
 			viewDate: viewDate,
 			selectedDate: selectedDate,
-			inputValue: selectedDate ? selectedDate.format( formats.datetime ) : (date || ''),
+			inputValue: inputValue,
 			open: props.open
 		};
 	},

--- a/tests/datetime-spec.js
+++ b/tests/datetime-spec.js
@@ -621,6 +621,18 @@ describe( 'Datetime', function(){
 		ev.change( dt.input() );
 	});
 
+	it( 'invalid moment object as input value', function( done ){
+		var value = moment(null);
+		createDatetime({ value: value, onChange: function( updated ){
+			assert.equal( mDate.format('L LT'), updated.format('L LT') );
+			done();
+		}});
+
+		assert.equal( dt.input().value, '' );
+		dt.input().value = strDate;
+		ev.change( dt.input() );
+	});
+
 	it( 'delete input value', function( done ){
 		createDatetime({ defaultValue: date, onChange: function( date ){
 			assert.equal( date, '' );


### PR DESCRIPTION
## Description
The component used to accept an invalid moment object which would have `NaN` as value and would display the value in the input element. This commit changes the value to `''` if this type of object is passed to it.

## Motivation and Context
I do not think `NaN` is an acceptable value for the input field, therefore I think we should handle that case and replace it with an empty string. This PR solves [this](https://github.com/YouCanBookMe/react-datetime/issues/140) issue.

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.