### PR TITLE
Signpost type definition file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/arqex/react-datetime"
   },
   "main": "./DateTime.js",
+  "types": "./react-datetime.d.ts",
   "scripts": {
     "build:win": "./node_modules/.bin/gulp.cmd",
     "build:mac": "./node_modules/.bin/gulp",


### PR DESCRIPTION
Without this option typescript doesn't find the current type definitions automatically.

For more info see the [docs for publishing type definitions](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).