### PR TITLE
Disable months and years according to isValidDate

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -3,6 +3,12 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 
 ReactDOM.render(
-  React.createElement(DateTime, { timeFormat: true }),
+  React.createElement(DateTime, {
+    viewMode: 'months',
+    dateFormat: 'MMMM',
+    isValidDate: function(current){
+      return current.isBefore(DateTime.moment().startOf('month'));
+    }
+  }),
   document.getElementById('datetime')
 );

--- a/src/MonthsView.js
+++ b/src/MonthsView.js
@@ -23,13 +23,14 @@ var DateTimePickerMonths = React.createClass({
 			i = 0,
 			months = [],
 			renderer = this.props.renderMonth || this.renderMonth,
+			isValid = this.props.isValidDate || this.isValidDate,
 			classes, props
 		;
 
 		while (i < 12) {
 			classes = 'rdtMonth';
 			var currentMonth = this.props.viewDate.clone().set({ year: year, month: i, date: 1 });
-			var disabled = !this.props.isValidDate(currentMonth);
+			var disabled = !isValid(currentMonth);
 
 			if ( disabled )
 				classes += ' rdtDisabled';
@@ -40,9 +41,11 @@ var DateTimePickerMonths = React.createClass({
 			props = {
 				key: i,
 				'data-value': i,
-				className: classes,
-				onClick: this.props.updateOn === 'months'? this.updateSelectedMonth : this.props.setDate('month')
+				className: classes
 			};
+
+			if ( !disabled )
+				props.onClick = this.updateSelectedMonth;
 
 			months.push( renderer( props, i, year, date && date.clone() ));
 
@@ -67,6 +70,9 @@ var DateTimePickerMonths = React.createClass({
 			? capitalize( monthsShort.standalone[ month ] )
 			: monthsShort[ month ]
 		);
+	},
+	isValidDate: function(){
+		return 1;
 	}
 });
 

--- a/src/MonthsView.js
+++ b/src/MonthsView.js
@@ -28,6 +28,12 @@ var DateTimePickerMonths = React.createClass({
 
 		while (i < 12) {
 			classes = 'rdtMonth';
+			var currentMonth = this.props.viewDate.clone().set({ year: year, month: i, date: 1 });
+			var disabled = !this.props.isValidDate(currentMonth);
+
+			if ( disabled )
+				classes += ' rdtDisabled';
+
 			if ( date && i === month && year === date.year() )
 				classes += ' rdtActive';
 

--- a/src/MonthsView.js
+++ b/src/MonthsView.js
@@ -45,7 +45,7 @@ var DateTimePickerMonths = React.createClass({
 			};
 
 			if ( !disabled )
-				props.onClick = this.updateSelectedMonth;
+				props.onClick = this.props.updateOn === 'months'? this.updateSelectedMonth : this.props.setDate('month');
 
 			months.push( renderer( props, i, year, date && date.clone() ));
 

--- a/src/YearsView.js
+++ b/src/YearsView.js
@@ -23,23 +23,32 @@ var DateTimePickerYears = React.createClass({
 			rows = [],
 			renderer = this.props.renderYear || this.renderYear,
 			selectedDate = this.props.selectedDate,
+			isValid = this.props.isValidDate || this.isValidDate,
 			classes, props
 		;
 
 		year--;
 		while (i < 11) {
 			classes = 'rdtYear';
+			var currentYear = this.props.viewDate.clone().set({ year: year, month: 1, date: 1 });
 			if ( i === -1 | i === 10 )
 				classes += ' rdtOld';
+
+			var disabled = !isValid(currentYear);
+			if ( disabled )
+				classes += ' rdtDisabled';
+
 			if ( selectedDate && selectedDate.year() === year )
 				classes += ' rdtActive';
 
 			props = {
 				key: year,
 				'data-value': year,
-				className: classes,
-				onClick: this.props.updateOn === 'years' ? this.updateSelectedYear : this.props.setDate('year')
+				className: classes
 			};
+
+			if ( !disabled )
+				props.onClick = this.props.updateOn === 'years' ? this.updateSelectedYear : this.props.setDate('year');
 
 			years.push( renderer( props, year, selectedDate && selectedDate.clone() ));
 
@@ -61,6 +70,10 @@ var DateTimePickerYears = React.createClass({
 
 	renderYear: function( props, year ){
 		return DOM.td( props, year );
+	},
+
+	isValidDate: function(){
+		return 1;
 	}
 });
 

--- a/tests/datetime-spec.js
+++ b/tests/datetime-spec.js
@@ -663,4 +663,22 @@ describe( 'Datetime', function(){
 		dt.input().value = invalidStrDate;
 		ev.change( dt.input() );
 	});
+
+	it( 'disable months', function(){
+		createDatetime({ viewMode: 'months', isValidDate: function( current ){
+				return current.isBefore(moment('2016-06-01', 'YYYY-MM-DD'));
+		}});
+		assert.equal( dt.month(0).className, 'rdtMonth' );
+		assert.equal( dt.month(4).className, 'rdtMonth' );
+		assert.equal( dt.month(5).className, 'rdtMonth rdtDisabled' );
+		assert.equal( dt.month(11).className, 'rdtMonth rdtDisabled' );
+	});
+
+	it( 'disable years', function(){
+		createDatetime({ viewMode: 'years', isValidDate: function( current ){
+				return current.isBefore(moment('2016-01-01', 'YYYY-MM-DD'));
+		}});
+		assert.equal( dt.year(6).className, 'rdtYear' );
+		assert.equal( dt.year(7).className, 'rdtYear rdtDisabled' );
+	});
 });


### PR DESCRIPTION
Disable dates according to isValidDate function when the viewMode and dateFormat props are set.
## Description

My solution was to add a disabled class when the isValidDate is not satisfied and thus allowing the click accordingly!
## Motivation and Context

This should be fixed #129 
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change required changes to the documentation.
- \- [ ] I have updated the documentation accordingly.
- \- [ ] I have updated the TypeScript type definition accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
