### PR TITLE
Fixed the problem with displayed selected datetime not changing when the format props change

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -154,11 +154,8 @@ var Datetime = React.createClass({
 			update = {}
 		;
 
-		if ( nextProps.value !== this.props.value ){
+		if ( nextProps.value !== this.props.value || formats.datetime !== this.getFormats( this.props ).datetime ){
 			update = this.getStateFromProps( nextProps );
-		}
-		if ( formats.datetime !== this.getFormats( this.props ).datetime ) {
-			update.inputFormat = formats.datetime;
 		}
 
 		if ( update.open === undefined ){

--- a/example/formatChangeExample.js
+++ b/example/formatChangeExample.js
@@ -1,0 +1,32 @@
+var DateTime = require('../DateTime.js');
+var React = require('react');
+var ReactDOM = require('react-dom');
+var moment = require('moment');
+
+var Wrapper = React.createClass({
+	getInitialState: function() {
+		return {
+			dateFormat: 'YYYY-mm-DD'
+		};
+	},
+
+	updateFormat: function(format) {
+		console.log('changing state');
+		this.setState({
+			dateFormat: 'DD.mm.YYYY'
+		});
+	},
+
+	componentDidMount: function() {
+		setTimeout(this.updateFormat, 2000);
+	},
+
+	render: function() {
+		return React.createElement(DateTime, { dateFormat: this.state.dateFormat, timeFormat: false, defaultValue: moment()	 });
+	}
+});
+
+ReactDOM.render(
+  React.createElement(Wrapper),
+  document.getElementById('datetime')
+);


### PR DESCRIPTION
## Description

In case of dateFormat and/or timeFormat prop change, componentWillReceiveProps was updating only the inputFormat state, not updating the inputValue and leaving it in old format. The value would correctly updated to the new format when the user manually changes the selected datetime.
## Motivation and Context

Fixes https://github.com/YouCanBookMe/react-datetime/issues/166
## Checklist
- [ ] My change required changes to the documentation.
- \- [ ] I have updated the documentation accordingly.
- \- [ ] I have updated the TypeScript type definition accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Added example/formatChangeExample.js as demo for the format change. To run it simply replace example.js with formatChangeExample.js in example/webpack.config.js. Date format should change after 3 seconds.
