### PR TITLE
whitelist npm package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   },
   "main": "./DateTime.js",
   "files": [
-    "DateTime.js",
-    "react-datetime.d.ts",
-    "src",
-    "css",
-    "dist"
+    "./DateTime.js",
+    "./react-datetime.d.ts",
+    "./src",
+    "./css",
+    "./dist"
   ],
   "types": "./react-datetime.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,13 @@
     "url": "https://github.com/arqex/react-datetime"
   },
   "main": "./DateTime.js",
+  "files": [
+    "DateTime.js",
+    "react-datetime.d.ts",
+    "src",
+    "css",
+    "dist"
+  ],
   "types": "./react-datetime.d.ts",
   "scripts": {
     "build:win": "./node_modules/.bin/gulp.cmd",


### PR DESCRIPTION
The npm package includes several non-essential files. Let's trim those down using the `files` field.

```
$ npm pack
$ tar -tf react-datetime-2.6.0.tgz
# before:
package/.eslintrc.js
package/.npmignore
package/.travis.yml
package/CHANGELOG.md
package/CONTRIBUTING.md
package/DateTime.js
package/LICENSE
package/PULL_REQUEST_TEMPLATE.md
package/README.md
package/css/react-datetime.css
package/dist/react-datetime.js
package/dist/react-datetime.min.js
package/example/example.js
package/example/index.html
package/example/react-datetime.css
package/gulpfile.js
package/package.json
package/react-datetime.d.ts
package/src/DaysView.js
package/src/MonthsView.js
package/src/TimeView.js
package/src/YearsView.js
package/src/onClickOutside.js
package/tests/datetime-spec.js
package/tests/testdom.js

# after:
package/CHANGELOG.md
package/DateTime.js
package/LICENSE
package/README.md
package/css/react-datetime.css
package/dist/react-datetime.js
package/dist/react-datetime.min.js
package/package.json
package/react-datetime.d.ts
package/src/DaysView.js
package/src/MonthsView.js
package/src/TimeView.js
package/src/YearsView.js
package/src/onClickOutside.js

# removed:
package/.eslintrc.js
package/.npmignore
package/.travis.yml
package/CONTRIBUTING.md
package/PULL_REQUEST_TEMPLATE.md
package/example/example.js
package/example/index.html
package/example/react-datetime.css
package/gulpfile.js
package/tests/datetime-spec.js
package/tests/testdom.js
```