### PR TITLE
True stateless mode when prop `open` specified

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -26,6 +26,8 @@ var Datetime = React.createClass({
 		onFocus: TYPES.func,
 		onBlur: TYPES.func,
 		onChange: TYPES.func,
+		onOpen: TYPES.func,
+		onClose: TYPES.func,
 		locale: TYPES.string,
 		input: TYPES.bool,
 		// dateFormat: TYPES.string | TYPES.bool,
@@ -50,6 +52,8 @@ var Datetime = React.createClass({
 			onFocus: nof,
 			onBlur: nof,
 			onChange: nof,
+      onOpen: nof,
+      onClose: nof,
 			timeFormat: true,
 			timeConstraints: {},
 			dateFormat: true,
@@ -154,7 +158,7 @@ var Datetime = React.createClass({
 			update = {}
 		;
 
-		if ( nextProps.value !== this.props.value ){
+		if ( nextProps.value !== this.props.value || nextProps.open !== this.props.open ){
 			update = this.getStateFromProps( nextProps );
 		}
 		if ( formats.datetime !== this.getFormats( this.props ).datetime ) {
@@ -319,19 +323,28 @@ var Datetime = React.createClass({
 	openCalendar: function() {
 		if (!this.state.open) {
 			this.props.onFocus();
-			this.setState({ open: true });
+
+      if (this.props.open === undefined) {
+        this.setState({ open: true });
+      } else {
+        this.props.onOpen();
+      }
 		}
 	},
 
 	closeCalendar: function() {
-		this.setState({ open: false });
+    if ( this.props.open === undefined ){
+      this.setState({ open: false });
+    } else {
+      this.props.onClose();
+    }
+
 		this.props.onBlur( this.state.selectedDate || this.state.inputValue );
 	},
 
 	handleClickOutside: function(){
-		if ( this.props.input && this.state.open && !this.props.open ){
-			this.setState({ open: false });
-			this.props.onBlur( this.state.selectedDate || this.state.inputValue );
+		if ( this.props.input && this.state.open ){
+      this.closeCalendar();
 		}
 	},
 

--- a/dist/react-datetime.js
+++ b/dist/react-datetime.js
@@ -9,9 +9,9 @@ MIT: https://github.com/arqex/react-datetime/raw/master/LICENSE
 	else if(typeof define === 'function' && define.amd)
 		define(["React", "moment", "ReactDOM"], factory);
 	else if(typeof exports === 'object')
-		exports["Datetime"] = factory(require("React"), require("moment"), require("ReactDOM"));
+		exports["DatetimeContainer"] = factory(require("React"), require("moment"), require("ReactDOM"));
 	else
-		root["Datetime"] = factory(root["React"], root["moment"], root["ReactDOM"]);
+		root["DatetimeContainer"] = factory(root["React"], root["moment"], root["ReactDOM"]);
 })(this, function(__WEBPACK_EXTERNAL_MODULE_2__, __WEBPACK_EXTERNAL_MODULE_4__, __WEBPACK_EXTERNAL_MODULE_9__) {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache


### PR DESCRIPTION
## Description
True stateless mode when prop `open` specified.

## Motivation and Context
Internal component's state is resetting when a component is updating. The previous behavior of property `open` not working properly. Because of this picker is suddenly closing when it wasn't necessary to do (ex. after updating a redux state).
Now, when prop `open` is provided the stateless mode is turning on. So, when `Datetime` think if a widget has to be shown or closed it calls methods onOpen/onClose to let you decide how exactly prop `open` need to be changed.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change required changes to the documentation.
- - [ ] I have updated the documentation accordingly.
- - [ ] I have updated the TypeScript type definition accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

