### PR TITLE
added new props isValidMonth to enable or disable the particular month

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -7,7 +7,7 @@ var assign = require('object-assign'),
 	YearsView = require('./src/YearsView'),
 	TimeView = require('./src/TimeView'),
 	moment = require('moment')
-;
+	;
 
 var TYPES = React.PropTypes;
 var Datetime = React.createClass({
@@ -34,6 +34,7 @@ var Datetime = React.createClass({
 		timeConstraints: TYPES.object,
 		viewMode: TYPES.oneOf(['years', 'months', 'days', 'time']),
 		isValidDate: TYPES.func,
+		isValidMonth: TYPES.func,
 		open: TYPES.bool,
 		strictParsing: TYPES.bool,
 		closeOnSelect: TYPES.bool,
@@ -74,7 +75,7 @@ var Datetime = React.createClass({
 		var formats = this.getFormats( props ),
 			date = props.value || props.defaultValue,
 			selectedDate, viewDate, updateOn, inputValue
-		;
+			;
 
 		if ( date && typeof date === 'string' )
 			selectedDate = this.localMoment( date, formats.datetime );
@@ -128,7 +129,7 @@ var Datetime = React.createClass({
 				time: props.timeFormat || ''
 			},
 			locale = this.localMoment( props.date ).localeData()
-		;
+			;
 
 		if ( formats.date === true ){
 			formats.date = locale.longDateFormat('L');
@@ -142,8 +143,8 @@ var Datetime = React.createClass({
 		}
 
 		formats.datetime = formats.date && formats.time ?
-			formats.date + ' ' + formats.time :
-			formats.date || formats.time
+		formats.date + ' ' + formats.time :
+		formats.date || formats.time
 		;
 
 		return formats;
@@ -152,7 +153,7 @@ var Datetime = React.createClass({
 	componentWillReceiveProps: function(nextProps) {
 		var formats = this.getFormats( nextProps ),
 			update = {}
-		;
+			;
 
 		if ( nextProps.value !== this.props.value ){
 			update = this.getStateFromProps( nextProps );
@@ -177,7 +178,7 @@ var Datetime = React.createClass({
 		var value = e.target === null ? e : e.target.value,
 			localMoment = this.localMoment( value, this.state.inputFormat ),
 			update = { inputValue: value }
-		;
+			;
 
 		if ( localMoment.isValid() && !this.props.value ) {
 			update.selectedDate = localMoment;
@@ -211,7 +212,7 @@ var Datetime = React.createClass({
 				month: 'days',
 				year: 'months'
 			}
-		;
+			;
 		return function( e ){
 			me.setState({
 				viewDate: me.state.viewDate.clone()[ type ]( parseInt(e.target.getAttribute('data-value'), 10) ).startOf( type ),
@@ -234,7 +235,7 @@ var Datetime = React.createClass({
 		return function(){
 			var update = {},
 				date = toSelected ? 'selectedDate' : 'viewDate'
-			;
+				;
 
 			update[ date ] = me.state[ date ].clone()[ op ]( amount, type );
 
@@ -248,7 +249,7 @@ var Datetime = React.createClass({
 			state = this.state,
 			date = (state.selectedDate || state.viewDate).clone(),
 			nextType
-		;
+			;
 
 		// It is needed to set all the time properties
 		// to not to reset the time
@@ -273,7 +274,7 @@ var Datetime = React.createClass({
 			viewDate = this.state.viewDate,
 			currentDate = this.state.selectedDate || viewDate,
 			date
-    ;
+			;
 
 		if (target.className.indexOf('rdtDay') !== -1){
 			if (target.className.indexOf('rdtNew') !== -1)
@@ -343,7 +344,7 @@ var Datetime = React.createClass({
 	},
 
 	componentProps: {
-		fromProps: ['value', 'isValidDate', 'renderDay', 'renderMonth', 'renderYear', 'timeConstraints'],
+		fromProps: ['value', 'isValidDate', 'isValidMonth', 'renderDay', 'renderMonth', 'renderYear', 'timeConstraints'],
 		fromState: ['viewDate', 'selectedDate', 'updateOn'],
 		fromThis: ['setDate', 'setTime', 'showView', 'addTime', 'subtractTime', 'updateSelectedDate', 'localMoment']
 	},
@@ -352,7 +353,7 @@ var Datetime = React.createClass({
 		var me = this,
 			formats = this.getFormats( this.props ),
 			props = {dateFormat: formats.date, timeFormat: formats.time}
-		;
+			;
 
 		this.componentProps.fromProps.forEach( function( name ){
 			props[ name ] = me.props[ name ];
@@ -371,10 +372,10 @@ var Datetime = React.createClass({
 		var Component = this.viewComponents[ this.state.currentView ],
 			DOM = React.DOM,
 			className = 'rdt' + (this.props.className ?
-                  ( Array.isArray( this.props.className ) ?
-                  ' ' + this.props.className.join( ' ' ) : ' ' + this.props.className) : ''),
+					( Array.isArray( this.props.className ) ?
+					' ' + this.props.className.join( ' ' ) : ' ' + this.props.className) : ''),
 			children = []
-		;
+			;
 
 		if ( this.props.input ){
 			children = [ DOM.input( assign({

--- a/src/MonthsView.js
+++ b/src/MonthsView.js
@@ -23,20 +23,32 @@ var DateTimePickerMonths = React.createClass({
 			i = 0,
 			months = [],
 			renderer = this.props.renderMonth || this.renderMonth,
-			classes, props
-		;
+			isValid = this.props.isValidMonth || this.isValidMonth,
+			currentDate = this.props.viewDate.clone(),
+			classes, props, disabled
+			;
+
+		currentDate.startOf('year');
 
 		while (i < 12) {
 			classes = 'rdtMonth';
+
 			if ( date && i === month && year === date.year() )
 				classes += ' rdtActive';
+
+			disabled = !isValid( currentDate, date );
+
+			if ( disabled )
+				classes += ' rdtDisabled';
 
 			props = {
 				key: i,
 				'data-value': i,
-				className: classes,
-				onClick: this.props.updateOn === 'months'? this.updateSelectedMonth : this.props.setDate('month')
+				className: classes
 			};
+
+			if ( !disabled )
+				props.onClick = (this.props.updateOn === 'months'? this.updateSelectedMonth : this.props.setDate('month'));
 
 			months.push( renderer( props, i, year, date && date.clone() ));
 
@@ -44,7 +56,7 @@ var DateTimePickerMonths = React.createClass({
 				rows.push( DOM.tr({ key: month + '_' + rows.length }, months) );
 				months = [];
 			}
-
+			currentDate.add(1, 'month');
 			i++;
 		}
 
@@ -62,6 +74,9 @@ var DateTimePickerMonths = React.createClass({
 			: monthsShort[ month ]
 		);
 	}
+
+	,
+	isValidMonth: function(){ return 1; }
 });
 
 function capitalize(str) {


### PR DESCRIPTION
Added new props to validate the month view

## Description
We have month only view. For this option I want to disable or enable click on months based on some condition. For this I added isValidMonth props. (Similar like isValidDate).

## Motivation and Context
This should be merged, because its mandatory if any want to disable and enable in month view based on condition.
Yes it does, Now we have control to enable and disable even in Month only view.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My change required changes to the documentation.
- - [ ] I have updated the documentation accordingly.
- - [ ] I have updated the TypeScript type definition accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.

