### PR TITLE
Add support for inputting times as UTC

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -27,6 +27,7 @@ var Datetime = React.createClass({
 		onBlur: TYPES.func,
 		onChange: TYPES.func,
 		locale: TYPES.string,
+		utc: TYPES.bool,
 		input: TYPES.bool,
 		// dateFormat: TYPES.string | TYPES.bool,
 		// timeFormat: TYPES.string | TYPES.bool,
@@ -55,7 +56,8 @@ var Datetime = React.createClass({
 			dateFormat: true,
 			strictParsing: true,
 			closeOnSelect: false,
-			closeOnTab: true
+			closeOnTab: true,
+			utc: false
 		};
 	},
 
@@ -336,7 +338,8 @@ var Datetime = React.createClass({
 	},
 
 	localMoment: function( date, format ){
-		var m = moment( date, format, this.props.strictParsing );
+		var momentFn = this.props.utc ? moment.utc : moment;
+		var m = momentFn( date, format, this.props.strictParsing );
 		if ( this.props.locale )
 			m.locale( this.props.locale );
 		return m;

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ render: function() {
 | **input** | `boolean` | `true` | Whether to show an input field to edit the date manually. |
 | **open** | `boolean` | `null` | Whether to open or close the picker. If not set react-datetime will open the datepicker on input focus and close it on click outside. |
 | **locale** | `string` | `null` | Manually set the locale for the react-datetime instance. Moment.js locale needs to be loaded to be used, see [i18n docs](#i18n).
+| **utc** | `boolean` | `false` | When true, input time values will be interpreted as UTC (Zulu time) by Moment.js. Otherwise they will default to the user's local timezone.
 | **onChange** | `function` | empty function | Callback trigger when the date changes. The callback receives the selected `moment` object as only parameter, if the date in the input is valid. If the date in the input is not valid, the callback receives the value of the input (a string). |
 | **onFocus** | `function` | empty function | Callback trigger for when the user opens the datepicker. |
 | **onBlur** | `function` | empty function | Callback trigger for when the user clicks outside of the input, simulating a regular onBlur. The callback receives the selected `moment` object as only parameter, if the date in the input is valid. If the date in the input is not valid, the callback returned. |

--- a/react-datetime.d.ts
+++ b/react-datetime.d.ts
@@ -46,6 +46,10 @@ declare module ReactDatetime {
      */
     locale?: string;
     /*
+     Whether to interpret input times as UTC or the user's local timezone.
+     */
+    utc?: boolean;
+    /*
      Callback trigger when the date changes. The callback receives the selected `moment` object as
      only parameter, if the date in the input is valid. If the date in the input is not valid, the
      callback receives the value of the input (a string).
@@ -113,7 +117,7 @@ declare module ReactDatetime {
      it will change adding or subtracting 2 hours everytime the buttons are clicked. The constraints
      can be added to the hours, minutes, seconds and milliseconds.
     */
-    timeConstraints?: Object; 
+    timeConstraints?: Object;
     /*
      When true, keep the picker open when click event is triggered outside of component. When false,
      close it.

--- a/tests/datetime-spec.js
+++ b/tests/datetime-spec.js
@@ -86,7 +86,9 @@ var dt = {
 
 var date = new Date( 2000, 0, 15, 2, 2, 2, 2 ),
 	mDate = moment( date ),
-	strDate = mDate.format('L') + ' ' + mDate.format('LT')
+	strDate = mDate.format('L') + ' ' + mDate.format('LT'),
+	mDateUTC = moment.utc(date),
+	strDateUTC = mDateUTC.format('L') + ' ' + mDateUTC.format('LT')
 ;
 
 describe( 'Datetime', function(){
@@ -125,6 +127,33 @@ describe( 'Datetime', function(){
 			input = component.children[0]
 		;
 		assert.equal( input.value, strDate );
+	});
+
+	it( 'UTC Value from local moment.', function(){
+		var component = createDatetime({
+			value: mDate,
+			utc: true
+		});
+		var input = component.children[0];
+		assert.equal( input.value, strDateUTC );
+	});
+
+	it( 'UTC Value from UTC moment.', function(){
+		var component = createDatetime({
+			value: mDateUTC,
+			utc: true
+		});
+		var input = component.children[0];
+		assert.equal( input.value, strDateUTC );
+	});
+
+	it( 'UTC Value from utc string.', function(){
+		var component = createDatetime({
+			value: strDateUTC,
+			utc: true
+		});
+		var input = component.children[0];
+		assert.equal( input.value, strDateUTC );
 	});
 
 	it( 'Date defaultValue', function(){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
This change adds a boolean `utc` prop. When set to `true`, it will cause moment to interpret input times as UTC, rather than the user's local timezone.

## Motivation and Context
<!--- Why do you think this pull request should be merged? -->
This PR will help anyone who deals with timestamps primarily in UTC, for example anyone operating in UTC or across multiple timezones.

<!--- Does it solve a problem, in that case what problem? -->
I build tools to manage a fleet of satellites in low earth orbit, where local time zones don't make any sense. All of our data is stored and queried as UTC. This change will allow my users to query the dataset using its native timezone.

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change required changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the TypeScript type definition accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

