### PR TITLE
Open the date picker upwards using direction prop

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -2,6 +2,7 @@
 
 var assign = require('object-assign'),
 	React = require('react'),
+  ReactDOM = require('react-dom'),
 	DaysView = require('./src/DaysView'),
 	MonthsView = require('./src/MonthsView'),
 	YearsView = require('./src/YearsView'),
@@ -37,7 +38,8 @@ var Datetime = React.createClass({
 		open: TYPES.bool,
 		strictParsing: TYPES.bool,
 		closeOnSelect: TYPES.bool,
-		closeOnTab: TYPES.bool
+		closeOnTab: TYPES.bool,
+    direction: TYPES.oneOf(['down', 'up'])
 	},
 
 	getDefaultProps: function() {
@@ -55,7 +57,8 @@ var Datetime = React.createClass({
 			dateFormat: true,
 			strictParsing: true,
 			closeOnSelect: false,
-			closeOnTab: true
+			closeOnTab: true,
+      direction: 'down'
 		};
 	},
 
@@ -366,6 +369,22 @@ var Datetime = React.createClass({
 
 		return props;
 	},
+
+  componentDidUpdate: function() {
+    this.updatePickerPosition();
+  },
+
+  componentDidMount: function() {
+    this.updatePickerPosition();
+  },
+
+  updatePickerPosition: function () {
+    if (this.state.open && this.props.direction === 'up') {
+      var parent = ReactDOM.findDOMNode(this);
+      var picker = parent.querySelector('.rdtPicker');
+      picker.style.top = '-' + picker.offsetHeight + 'px';
+    }
+  },
 
 	render: function() {
 		var Component = this.viewComponents[ this.state.currentView ],

--- a/example/example.js
+++ b/example/example.js
@@ -6,3 +6,7 @@ ReactDOM.render(
   React.createElement(DateTime, { timeFormat: true }),
   document.getElementById('datetime')
 );
+ReactDOM.render(
+  React.createElement(DateTime, { timeFormat: true, direction: 'up' }),
+  document.getElementById('datetime--footer')
+);

--- a/example/index.html
+++ b/example/index.html
@@ -3,9 +3,17 @@
 <head>
  <title>DateTime</title>
  <link rel="stylesheet" type="text/css" href="react-datetime.css">
+ <style>
+  #datetime--footer {
+    position: absolute;
+    bottom: 20px;
+  }
+ </style>
 </head>
 <body>
  <div id="datetime">
+ </div>
+ <div id="datetime--footer">
  </div>
 
  <script src="http://localhost:8080/webpack-dev-server.js"></script>

--- a/tests/datetime-spec.js
+++ b/tests/datetime-spec.js
@@ -215,11 +215,11 @@ describe( 'Datetime', function(){
 		assert.notEqual( component.className.indexOf('custom'), -1 );
 	});
 
-    it( 'className of type string array', function(){
-        var component = createDatetime({ className: ['custom1', 'custom2'] });
-        assert.notEqual( component.className.indexOf('custom1'), -1 );
-        assert.notEqual( component.className.indexOf('custom2'), -1 );
-    });
+  it( 'className of type string array', function(){
+      var component = createDatetime({ className: ['custom1', 'custom2'] });
+      assert.notEqual( component.className.indexOf('custom1'), -1 );
+      assert.notEqual( component.className.indexOf('custom2'), -1 );
+  });
 
 	it( 'inputProps', function(){
 		var component = createDatetime({ inputProps: { className: 'myInput', type: 'email' } }),


### PR DESCRIPTION
## Description
An inital 5-minute attempt at providing the enhancement requested in issue 171.
Just an initial request for feedback. Is the approach acceptable or awful?

## Motivation and Context
- https://github.com/YouCanBookMe/react-datetime/issues/171

Motivation for the PR is to get the ball rolling. TBH, this enhancement is enough for me.

However, I still need to add to the doco and write a test.

I can also see alternative approaches, all more laborious:

1. Ideally there'd be a direction: 'youKnowBest' option in which the component looks around its bounds to decide which way is best to open.
2. I think there's viable CSS-only approach to the 'up' case. 

What's your preference?

## Checklist
- [Y] My change required changes to the documentation.
- - [N] I have updated the documentation accordingly.
- - [N] I have updated the TypeScript type definition accordingly.
- [N] I have added tests to cover my changes.
- [Y] All new and existing tests passed.

