### PR TITLE
Update typings for Typescript 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ node_js:
 - '4'
 script:
 - npm run lint
+- npm run test:typings
 - npm run test

--- a/README.md
+++ b/README.md
@@ -135,16 +135,11 @@ This project includes typings for Typescript 2.0. Additional typings are not
 required.
 
 ```js
-import * as React from 'react';
 import Datetime = require('react-datetime');
 
 class MyDTPicker extends React.Component<MyDTPickerProps, MyDTPickerState> {
-    render():JSX.Element {
-        return <Datetime
-            renderDay={ this.renderDay }
-            renderMonth={ this.renderMonth }
-            renderYear={ this.renderYear }
-        />;
+    render(): JSX.Element {
+        return <Datetime />;
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ This project includes typings for Typescript 2.0. Additional typings are not
 required.
 
 ```js
-import Datetime = require('react-datetime');
+import * as Datetime  from 'react-datetime';
 
 class MyDTPicker extends React.Component<MyDTPickerProps, MyDTPickerState> {
-    render(): JSX.Element {
+    render() JSX.Element {
         return <Datetime />;
     }
 }

--- a/README.md
+++ b/README.md
@@ -129,6 +129,26 @@ var valid = function( current ){
 ```
 [Working example of disabled weekends here.](http://codepen.io/simeg/pen/jVVKWq)
 
+## Usage with Typescript
+
+This project includes typings for Typescript 2.0. Additional typings are not
+required.
+
+```js
+import * as React from 'react';
+import Datetime = require('react-datetime');
+
+class MyDTPicker extends React.Component<MyDTPickerProps, MyDTPickerState> {
+    render():JSX.Element {
+        return <Datetime
+            renderDay={ this.renderDay }
+            renderMonth={ this.renderMonth }
+            renderYear={ this.renderYear }
+        />;
+    }
+}
+```
+
 ## Contributions
 * For information about how to contribute, see the [CONTRIBUTING](CONTRIBUTING.md) file.
 * For development we recommend that you use [react-datetime-playground](https://github.com/arqex/react-datetime-playground).

--- a/package.json
+++ b/package.json
@@ -10,19 +10,20 @@
   "main": "./DateTime.js",
   "files": [
     "DateTime.js",
-    "react-datetime.d.ts",
+    "typings/index.d.ts",
     "src",
     "css",
     "dist"
   ],
-  "types": "./react-datetime.d.ts",
+  "types": "./typings/index.d.ts",
   "scripts": {
     "build:win": "./node_modules/.bin/gulp.cmd",
     "build:mac": "./node_modules/.bin/gulp",
     "test": "node node_modules/mocha/bin/mocha tests",
     "test:watch": "node node_modules/mocha/bin/mocha --watch tests",
     "dev": "webpack-dev-server --config example/webpack.config.js --devtool eval --progress --colors --hot --content-base example",
-    "lint": "./node_modules/.bin/eslint src/ DateTime.js"
+    "lint": "./node_modules/.bin/eslint src/ DateTime.js",
+    "test:typings": "tsc -p ./typings"
   },
   "keywords": [
     "react",
@@ -40,6 +41,7 @@
     "moment": ">=2.16.0"
   },
   "devDependencies": {
+    "@types/react": "^0.14.49",
     "eslint": "^3.1.0",
     "gulp": "^3.9.0",
     "gulp-insert": "^0.4.0",
@@ -53,6 +55,7 @@
     "react-addons-test-utils": ">=0.13",
     "react-dom": ">=0.13",
     "react-tools": "^0.13.2",
+    "typescript": "^2.0.10",
     "webpack": "^1.5.1",
     "webpack-dev-server": "^1.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "main": "./DateTime.js",
   "files": [
     "DateTime.js",
+    "react-datetime.d.ts",
     "typings/index.d.ts",
     "src",
     "css",

--- a/react-datetime.d.ts
+++ b/react-datetime.d.ts
@@ -1,0 +1,135 @@
+// Type definitions for react-datetime
+// Project: https://github.com/YouCanBookMe/react-datetime
+// Definitions by: Ivan Verevkin <vereva@x-root.org>
+
+//// <reference path="../moment/moment-node.d.ts" />
+
+declare module ReactDatetime {
+  import React = __React;
+  // import * as moment from 'moment';
+
+  export interface DatetimepickerProps {
+    /*
+     Represents the selected date by the component, in order to use it as a controlled component.
+     This prop is parsed by moment.js, so it is possible to use a date string or a moment.js date.
+     */
+    value?: Date;
+    /*
+     Represents the selected date for the component to use it as a uncontrolled component.
+     This prop is parsed by moment.js, so it is possible to use a date string or a moment.js date.
+     */
+    defaultValue?: Date;
+    /*
+     Defines the format for the date. It accepts any moment.js date format.
+     If true the date will be displayed using the defaults for the current locale.
+     If false the datepicker is disabled and the component can be used as timepicker.
+     */
+    dateFormat?: boolean|string;
+    /*
+     Defines the format for the time. It accepts any moment.js time format.
+     If true the time will be displayed using the defaults for the current locale.
+     If false the timepicker is disabled and the component can be used as datepicker.
+     */
+    timeFormat?: boolean|string;
+    /*
+     Whether to show an input field to edit the date manually.
+     */
+    input?: boolean;
+    /*
+     Whether to open or close the picker. If not set react-datetime will open the
+     datepicker on input focus and close it on click outside.
+     */
+    open?: boolean;
+    /*
+     Manually set the locale for the react-datetime instance.
+     Moment.js locale needs to be loaded to be used, see i18n docs.
+     */
+    locale?: string;
+    /*
+     Whether to interpret input times as UTC or the user's local timezone.
+     */
+    utc?: boolean;
+    /*
+     Callback trigger when the date changes. The callback receives the selected `moment` object as
+     only parameter, if the date in the input is valid. If the date in the input is not valid, the
+     callback receives the value of the input (a string).
+     */
+    onChange?: (momentOrInputString: string|any) => void;
+    /*
+     Callback trigger for when the user opens the datepicker.
+     */
+    onFocus?: () => void;
+    /*
+     Callback trigger for when the user clicks outside of the input, simulating a regular onBlur.
+     The callback receives the selected `moment` object as only parameter, if the date in the input
+     is valid. If the date in the input is not valid, the callback receives the value of the
+     input (a string).
+     */
+    onBlur?: (momentOrInputString : string|any) => void;
+    /*
+     The default view to display when the picker is shown. ('years', 'months', 'days', 'time')
+     */
+    viewMode?: string|number;
+    /*
+     Extra class names for the component markup.
+     */
+    className?: string;
+    /*
+     Defines additional attributes for the input element of the component.
+     */
+    inputProps?: Object;
+    /*
+     Define the dates that can be selected. The function receives (currentDate, selectedDate)
+     and should return a true or false whether the currentDate is valid or not. See selectable dates.
+     */
+    isValidDate?: (currentDate: any, selectedDate: any) => boolean;
+    /*
+     Customize the way that the days are shown in the day picker. The accepted function has
+     the selectedDate, the current date and the default calculated props for the cell,
+     and must return a React component. See appearance customization
+     */
+    renderDay?: (props: any, currentDate: any, selectedDate: any) => React.Component<any, any>;
+    /*
+     Customize the way that the months are shown in the month picker.
+     The accepted function has the selectedDate, the current date and the default calculated
+     props for the cell, the month and the year to be shown, and must return a
+     React component. See appearance customization
+     */
+    renderMonth?: (props: any, month: number, year: number, selectedDate: any) => React.Component<any, any>;
+    /*
+     Customize the way that the years are shown in the year picker.
+     The accepted function has the selectedDate, the current date and the default calculated
+     props for the cell, the year to be shown, and must return a React component.
+     See appearance customization
+     */
+    renderYear?: (props: any, year: number, selectedDate: any) => React.Component<any, any>;
+    /*
+     Whether to use moment's strict parsing when parsing input.
+     */
+    strictParsing?: boolean;
+    /*
+     When true, once the day has been selected, the react-datetime will be automatically closed.
+     */
+    closeOnSelect?: boolean;
+    /*
+     Allow to add some constraints to the time selector. It accepts an object with the format
+     {hours:{ min: 9, max: 15, step:2}} so the hours can't be lower than 9 or higher than 15, and
+     it will change adding or subtracting 2 hours everytime the buttons are clicked. The constraints
+     can be added to the hours, minutes, seconds and milliseconds.
+    */
+    timeConstraints?: Object;
+    /*
+     When true, keep the picker open when click event is triggered outside of component. When false,
+     close it.
+    */
+    disableOnClickOutside?: boolean;
+  }
+
+  interface DatetimeComponent extends React.ComponentClass<DatetimepickerProps> {
+  }
+}
+
+declare module "react-datetime" {
+  var ReactDatetime: ReactDatetime.DatetimeComponent;
+  export = ReactDatetime;
+}

--- a/react-datetime.d.ts
+++ b/react-datetime.d.ts
@@ -2,6 +2,9 @@
 // Project: https://github.com/YouCanBookMe/react-datetime
 // Definitions by: Ivan Verevkin <vereva@x-root.org>
 
+// These are the typings for Typescript 1.8
+// for Typescrip 2.0+ see typings/index.d.ts
+
 //// <reference path="../moment/moment-node.d.ts" />
 
 declare module ReactDatetime {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,14 +1,35 @@
 // Type definitions for react-datetime
 // Project: https://github.com/YouCanBookMe/react-datetime
 // Definitions by: Ivan Verevkin <vereva@x-root.org>
+//     Updates by: Aaron Spaulding <aaron@sachimp.com>
 
-//// <reference path="../moment/moment-node.d.ts" />
+declare module "react-datetime" {
 
-declare module ReactDatetime {
-  import React = __React;
-  // import * as moment from 'moment';
+  /*
+   A stand-in type for Moment, this file currently has no way of guaranteeing
+   the existence of those typings.
+   */
+  type Moment = any;
 
-  export interface DatetimepickerProps {
+  /*
+   The view mode can be any of the following strings.
+   */
+  type ViewMode = 'years' | 'months' | 'days' | 'time';
+
+  interface TimeConstraint {
+    min: number;
+    max: number;
+    step: number;
+  }
+
+  interface TimeConstraints {
+    hours?: TimeConstraint;
+    minutes?: TimeConstraint;
+    seconds?: TimeConstraint;
+    milliseconds?: TimeConstraint;
+  }
+
+  interface DatetimepickerProps {
     /*
      Represents the selected date by the component, in order to use it as a controlled component.
      This prop is parsed by moment.js, so it is possible to use a date string or a moment.js date.
@@ -46,15 +67,11 @@ declare module ReactDatetime {
      */
     locale?: string;
     /*
-     Whether to interpret input times as UTC or the user's local timezone.
-     */
-    utc?: boolean;
-    /*
      Callback trigger when the date changes. The callback receives the selected `moment` object as
      only parameter, if the date in the input is valid. If the date in the input is not valid, the
      callback receives the value of the input (a string).
      */
-    onChange?: (momentOrInputString: string|any) => void;
+    onChange?: (momentOrInputString: string|Moment) => void;
     /*
      Callback trigger for when the user opens the datepicker.
      */
@@ -65,11 +82,11 @@ declare module ReactDatetime {
      is valid. If the date in the input is not valid, the callback receives the value of the
      input (a string).
      */
-    onBlur?: (momentOrInputString : string|any) => void;
+    onBlur?: (momentOrInputString : string|Moment) => void;
     /*
      The default view to display when the picker is shown. ('years', 'months', 'days', 'time')
      */
-    viewMode?: string|number;
+    viewMode?: ViewMode|number;
     /*
      Extra class names for the component markup.
      */
@@ -77,7 +94,7 @@ declare module ReactDatetime {
     /*
      Defines additional attributes for the input element of the component.
      */
-    inputProps?: Object;
+    inputProps?: React.HTMLProps<HTMLInputElement>;
     /*
      Define the dates that can be selected. The function receives (currentDate, selectedDate)
      and should return a true or false whether the currentDate is valid or not. See selectable dates.
@@ -88,21 +105,21 @@ declare module ReactDatetime {
      the selectedDate, the current date and the default calculated props for the cell,
      and must return a React component. See appearance customization
      */
-    renderDay?: (props: any, currentDate: any, selectedDate: any) => React.Component<any, any>;
+    renderDay?: (props: any, currentDate: any, selectedDate: any) => JSX.Element;
     /*
      Customize the way that the months are shown in the month picker.
      The accepted function has the selectedDate, the current date and the default calculated
      props for the cell, the month and the year to be shown, and must return a
      React component. See appearance customization
      */
-    renderMonth?: (props: any, month: number, year: number, selectedDate: any) => React.Component<any, any>;
+    renderMonth?: (props: any, month: number, year: number, selectedDate: any) => JSX.Element;
     /*
      Customize the way that the years are shown in the year picker.
      The accepted function has the selectedDate, the current date and the default calculated
      props for the cell, the year to be shown, and must return a React component.
      See appearance customization
      */
-    renderYear?: (props: any, year: number, selectedDate: any) => React.Component<any, any>;
+    renderYear?: (props: any, year: number, selectedDate: any) => JSX.Element;
     /*
      Whether to use moment's strict parsing when parsing input.
      */
@@ -117,7 +134,7 @@ declare module ReactDatetime {
      it will change adding or subtracting 2 hours everytime the buttons are clicked. The constraints
      can be added to the hours, minutes, seconds and milliseconds.
     */
-    timeConstraints?: Object;
+    timeConstraints?: TimeConstraints;
     /*
      When true, keep the picker open when click event is triggered outside of component. When false,
      close it.
@@ -125,11 +142,17 @@ declare module ReactDatetime {
     disableOnClickOutside?: boolean;
   }
 
-  interface DatetimeComponent extends React.ComponentClass<DatetimepickerProps> {
+  interface DatetimepickerState {
+      updateOn: string;
+      inputFormat: string;
+      viewDate: Moment;
+      selectedDate: Moment;
+      inputValue: string;
+      open: boolean;
   }
-}
 
-declare module "react-datetime" {
-  var ReactDatetime: ReactDatetime.DatetimeComponent;
+  class ReactDatetime extends React.Component<DatetimepickerProps, DatetimepickerState> {
+  }
+
   export = ReactDatetime;
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Ivan Verevkin <vereva@x-root.org>
 //     Updates by: Aaron Spaulding <aaron@sachimp.com>
 
-declare module "react-datetime" {
+declare module 'react-datetime' {
 
   /*
    A stand-in type for Moment, this file currently has no way of guaranteeing
@@ -66,6 +66,10 @@ declare module "react-datetime" {
      Moment.js locale needs to be loaded to be used, see i18n docs.
      */
     locale?: string;
+    /*
+     Whether to interpret input times as UTC or the user's local timezone.
+     */
+    utc?: boolean;
     /*
      Callback trigger when the date changes. The callback receives the selected `moment` object as
      only parameter, if the date in the input is valid. If the date in the input is not valid, the

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -158,5 +158,11 @@ declare module 'react-datetime' {
   class ReactDatetime extends React.Component<DatetimepickerProps, DatetimepickerState> {
   }
 
+  /*
+   This is a hack for cleaner imports. It augments the ReactDatetime class to
+   make it a namespace which are importable using the 'import * as ...' syntax.
+   */
+  namespace ReactDatetime {}
+
   export = ReactDatetime;
 }

--- a/typings/react-datetime-tests.tsx
+++ b/typings/react-datetime-tests.tsx
@@ -25,8 +25,8 @@ const TEST_DATE_PROPS_FOR_DEFAULT_VALUE: JSX.Element = <ReactDatetime
  */
 
 const TEST_FORMAT_PROPS_AS_STRINGS: JSX.Element = <ReactDatetime
-		dateFormat="mm/dd/yyyy"
-		timeFormat="hh:mm:ss"
+		dateFormat='mm/dd/yyyy'
+		timeFormat='hh:mm:ss'
 	/>;
 
 const TEST_FORMAT_PROPS_AS_BOOLEANS: JSX.Element = <ReactDatetime
@@ -44,6 +44,7 @@ const TEST_BOOLEAN_PROPS: JSX.Element = <ReactDatetime
 		strictParsing={ false }
 		closeOnSelect={ false }
 		disableOnClickOutside={ false }
+		utc={ false }
 	/>;
 
 /*
@@ -51,7 +52,7 @@ const TEST_BOOLEAN_PROPS: JSX.Element = <ReactDatetime
  */
 
 const TEST_LOCALE_PROPS: JSX.Element = <ReactDatetime
-		locale="en-us"
+		locale='en-us'
 	/>;
 
 /*
@@ -96,8 +97,8 @@ const TEST_EVENT_HANDLERS_WITH_MOMENT: JSX.Element = <ReactDatetime
  */
 
 const TEST_VIEW_MODE_AND_CLASS_PROPS: JSX.Element = <ReactDatetime
-		viewMode="days"
-		className="rdt"
+		viewMode='days'
+		className='rdt'
 	/>;
 
 /*
@@ -121,7 +122,7 @@ const TEST_CUSTOMIZABLE_COMPONENT_PROPS: JSX.Element = <ReactDatetime
 		renderMonth={ (props, month, year, selectedDate) => {
 			return <td {...props}>{ month }</td>;
 		} }
-		renderYear={ ( props, year, selectedDate ) => {
+		renderYear={ (props, year, selectedDate) => {
 			return <td {...props}>{ year % 100 }</td>;
 		} }
 	/>;

--- a/typings/react-datetime-tests.tsx
+++ b/typings/react-datetime-tests.tsx
@@ -1,0 +1,170 @@
+import * as React from 'react';
+import { Moment } from 'moment';
+import ReactDatetime = require('react-datetime');
+
+/*
+ Test the datetime picker.
+ */
+
+const TEST_BASIC_USAGE: JSX.Element = <ReactDatetime />;
+
+/*
+ Test date properties
+ */
+
+const TEST_DATE_PROPS_FOR_VALUE: JSX.Element = <ReactDatetime
+		value={ new Date() }
+	/>;
+
+const TEST_DATE_PROPS_FOR_DEFAULT_VALUE: JSX.Element = <ReactDatetime
+		defaultValue={ new Date() }
+	/>;
+
+/*
+ Test formats
+ */
+
+const TEST_FORMAT_PROPS_AS_STRINGS: JSX.Element = <ReactDatetime
+		dateFormat="mm/dd/yyyy"
+		timeFormat="hh:mm:ss"
+	/>;
+
+const TEST_FORMAT_PROPS_AS_BOOLEANS: JSX.Element = <ReactDatetime
+		dateFormat={ false }
+		timeFormat={ false }
+	/>;
+
+/*
+ Test boolean options
+ */
+
+const TEST_BOOLEAN_PROPS: JSX.Element = <ReactDatetime
+		input={ false }
+		open={ false }
+		strictParsing={ false }
+		closeOnSelect={ false }
+		disableOnClickOutside={ false }
+	/>;
+
+/*
+ Test locale options
+ */
+
+const TEST_LOCALE_PROPS: JSX.Element = <ReactDatetime
+		locale="en-us"
+	/>;
+
+/*
+ Test input props
+ */
+
+const TEST_INPUT_PROPS: JSX.Element = <ReactDatetime
+		inputProps={
+			{
+				'placeholder': 'mm/dd/yyyy'
+			}
+		}
+	/>;
+
+/*
+ Test Event handlers
+ */
+
+ const TEST_EVENT_HANDLERS_WITH_STRINGS: JSX.Element = <ReactDatetime
+ 		onChange={
+ 			(momentOrInputString:string) => {}
+ 		}
+		onFocus={
+			() => {}
+		}
+		onBlur={
+			(momentOrInputString:string) => {}
+		}
+ 	/>;
+
+const TEST_EVENT_HANDLERS_WITH_MOMENT: JSX.Element = <ReactDatetime
+		onChange={
+			(momentOrInputString:Moment) => {}
+		}
+		onBlur={
+			(momentOrInputString:Moment) => {}
+		}
+	/>;
+
+/*
+ Test view mode and className
+ */
+
+const TEST_VIEW_MODE_AND_CLASS_PROPS: JSX.Element = <ReactDatetime
+		viewMode="days"
+		className="rdt"
+	/>;
+
+/*
+ Test date validator
+ */
+
+const TEST_DATE_VALIDATOR_PROP: JSX.Element = <ReactDatetime
+		isValidDate={ (currentDate:any, selectedDate:any) => {
+			return true;
+		} }
+	/>;
+
+/*
+ Test customizable components
+ */
+
+const TEST_CUSTOMIZABLE_COMPONENT_PROPS: JSX.Element = <ReactDatetime
+		renderDay={ (props, currentDate, selectedDate) => {
+			return <td {...props}>{ '0' + currentDate.date() }</td>;
+		} }
+		renderMonth={ (props, month, year, selectedDate) => {
+			return <td {...props}>{ month }</td>;
+		} }
+		renderYear={ ( props, year, selectedDate ) => {
+			return <td {...props}>{ year % 100 }</td>;
+		} }
+	/>;
+
+/*
+ Test time constraints.
+ */
+
+const TEST_BASIC_TIME_CONSTRAINTS: JSX.Element = <ReactDatetime
+		timeConstraints={ {} }
+	/>;
+
+const TEST_TIME_CONSTRAINTS_WITH_ONE: JSX.Element = <ReactDatetime
+		timeConstraints={ {
+			'hours': {
+				'min': 0,
+				'max': 23,
+				'step': 1
+			}
+		} }
+	/>;
+
+const TEST_TIME_CONSTRAINTS_WITH_ALL: JSX.Element = <ReactDatetime
+		timeConstraints={ {
+			'hours': {
+				'min': 0,
+				'max': 23,
+				'step': 1
+			},
+			'minutes': {
+				'min': 0,
+				'max': 59,
+				'step': 1
+			},
+			'seconds': {
+				'min': 0,
+				'max': 59,
+				'step': 1,
+			},
+			'milliseconds': {
+				'min': 0,
+				'max': 999,
+				'step': 1
+			}
+		} }
+	/>;

--- a/typings/react-datetime-tests.tsx
+++ b/typings/react-datetime-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Moment } from 'moment';
-import ReactDatetime = require('react-datetime');
+import * as ReactDatetime from 'react-datetime';
 
 /*
  Test the datetime picker.

--- a/typings/tsconfig.json
+++ b/typings/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "noImplicitAny": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "jsx": "react"
+    },
+    "files": [
+        "index.d.ts",
+        "react-datetime-tests.tsx"
+    ]
+}

--- a/typings/tsconfig.json
+++ b/typings/tsconfig.json
@@ -2,10 +2,6 @@
     "compilerOptions": {
         "noImplicitAny": true,
         "strictNullChecks": false,
-        "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
         "types": [],
         "noEmit": true,
         "jsx": "react"


### PR DESCRIPTION
## Description
Typescript 2.0 has a new mechanism for resolving types for modules. This PR updates the typings for react-datetime to be compatible with with the latest typescript. It also includes a couple of fixes and enhancements to the typings.

- Restrict `viewMode` to the correct strings (or a number).
- Improve typings for `timeConstraints`
- Fix `renderDay`, `renderMonth`, `renderYear` to the correct return types.
- Improve typings for `inputProps`, limiting it to only those allowed on input elements
- Fix `ReactDatetime` to be a class

## Motivation and Context
Fixes issue #181. Improves compatibility with this package.

## Checklist
- [X] My change required changes to the documentation.
- - [X] I have updated the documentation accordingly.
- - [X] I have updated the TypeScript type definition accordingly. :P
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.