### PR TITLE
Create readOnly prop

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -38,7 +38,8 @@ var Datetime = React.createClass({
 		open: TYPES.bool,
 		strictParsing: TYPES.bool,
 		closeOnSelect: TYPES.bool,
-		closeOnTab: TYPES.bool
+		closeOnTab: TYPES.bool,
+		readOnly: TYPES.bool,
 	},
 
 	getDefaultProps: function() {
@@ -57,7 +58,8 @@ var Datetime = React.createClass({
 			strictParsing: true,
 			closeOnSelect: false,
 			closeOnTab: true,
-			utc: false
+			utc: false,
+			readOnly: false,
 		};
 	},
 
@@ -106,7 +108,8 @@ var Datetime = React.createClass({
 			viewDate: viewDate,
 			selectedDate: selectedDate,
 			inputValue: inputValue,
-			open: props.open
+			open: props.open,
+			readOnly: props.readOnly,
 		};
 	},
 
@@ -388,7 +391,8 @@ var Datetime = React.createClass({
 				onFocus: this.openCalendar,
 				onChange: this.onInputChange,
 				onKeyDown: this.onInputKey,
-				value: this.state.inputValue
+				value: this.state.inputValue,
+				readOnly: this.state.readOnly,
 			}, this.props.inputProps ))];
 		} else {
 			className += ' rdtStatic';

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ render: function() {
 | **closeOnTab** | `boolean` | `true` | When `true` and the input is focused, pressing the `tab` key will close the datepicker.
 | **timeConstraints** | `object` | `null` | Add some constraints to the timepicker. It accepts an `object` with the format `{ hours: { min: 9, max: 15, step: 2 }}`, this example means the hours can't be lower than `9` and higher than `15`, and it will change adding or subtracting `2` hours everytime the buttons are clicked. The constraints can be added to the `hours`, `minutes`, `seconds` and `milliseconds`.
 | **disableOnClickOutside** | `boolean` | `false` | When `true`, keep the datepicker open when click event is triggered outside of component. When `false`, close it.
+| **readOnly** | `boolean` | `false` | When `true`, the input acts as the usual readOnly prop does it react components. This is handy when soft keyboards on mobile devices are causing issues.
 
 ## i18n
 Different language and date formats are supported by react-datetime. React uses [Moment.js](http://momentjs.com/) to format the dates, and the easiest way of changing the language of the calendar is [changing the Moment.js locale](http://momentjs.com/docs/#/i18n/changing-locale/).


### PR DESCRIPTION
## Description
In this commit, I added a readOnly prop to the component.  This is making use of Reacts readOnly in order to keep from showing soft keyboards on mobile devices.  

## Motivation and Context
I noticed when on mobile, it was quirky getting the input to work properly because the soft keyboard kept popping up.  I added this as an option so the keyboard won't pop up at all and it makes the field read only, but the datepicker still works.  

## Checklist
- [X ] My change required changes to the documentation.
- - [ X] I have updated the documentation accordingly.
- - [ ] I have updated the TypeScript type definition accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

