### PR TITLE
Add workaround for programmatically open and close datepicker.

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -156,14 +156,24 @@ var Datetime = React.createClass({
 			update = {}
 		;
 
-		if ( nextProps.value !== this.props.value ||
-            formats.datetime !== this.getFormats( this.props ).datetime ){
-            update = this.getStateFromProps( nextProps );
+		if ( nextProps.value !== this.props.value){
+      update = this.getStateFromProps( nextProps );
+      // Close on select only makes sense if we actually changed value.
+      if ( this.props.closeOnSelect && this.state.currentView !== 'time' ){
+        update.open = false;
+      }
 		}
 
+		// Separated format update
+		if ( formats.datetime !== this.getFormats( this.props ).datetime ){
+			update.inputFormat = formats.datetime;
+		}
+
+		// If open has not been set before this moment,
+		// then we must have programmatically changed open property from outside.
 		if ( update.open === undefined ){
-			if ( this.props.closeOnSelect && this.state.currentView !== 'time' ){
-				update.open = false;
+			if ( nextProps.open !== this.props.open ){
+				update.open = nextProps.open;
 			}
 			else {
 				update.open = this.state.open;
@@ -331,7 +341,7 @@ var Datetime = React.createClass({
 	},
 
 	handleClickOutside: function(){
-		if ( this.props.input && this.state.open && !this.props.open ){
+		if ( this.props.input && this.state.open ){
 			this.setState({ open: false }, function() {
 				this.props.onBlur( this.state.selectedDate || this.state.inputValue );
 			});

--- a/example/DatepickerContainer.js
+++ b/example/DatepickerContainer.js
@@ -1,0 +1,39 @@
+var React = require('react');
+var DateTime = require('../DateTime');
+var DOM = React.DOM;
+
+module.exports = React.createClass({
+  getInitialState: function() {
+    return {
+      isOpen: this.props.open || false
+    };
+  },
+
+  render: function() {
+    var isOpen = this.state.isOpen;
+    function handleClick() {
+      this.setState({
+        isOpen: !this.state.isOpen
+      });
+    }
+    function handleBlur() {
+      this.setState({
+        isOpen: false
+      });
+    }
+
+    return DOM.div({
+      className: 'datepicker-container',
+    },
+      React.createElement(DateTime, Object.assign({}, this.props, {
+        open: isOpen,
+        onBlur: handleBlur.bind(this)
+      })),
+      DOM.button({
+        onClick: handleClick.bind(this),
+        className: 'open-datepicker',
+        children: 'Toggle open Datepicker'
+      })
+    );
+  }
+});

--- a/example/example.js
+++ b/example/example.js
@@ -1,11 +1,13 @@
 var DateTime = require('../DateTime.js');
 var React = require('react');
 var ReactDOM = require('react-dom');
+var DatepickerContainer = require('./DatepickerContainer');
 
 ReactDOM.render(
-  React.createElement(DateTime, {
+  React.createElement(DatepickerContainer, {
     viewMode: 'months',
     dateFormat: 'MMMM',
+    closeOnSelect: true,
     isValidDate: function(current){
       return current.isBefore(DateTime.moment().startOf('month'));
     }

--- a/tests/datetime-spec.js
+++ b/tests/datetime-spec.js
@@ -2,12 +2,12 @@
 var DOM = require( './testdom');
 DOM();
 
-
 // Needs to be global to work in Travis CI
-React = require('react');
-ReactDOM = require('react-dom');
+var React = require('react');
+var ReactDOM = require('react-dom');
 
 var Datetime = require('../DateTime'),
+	DatepickerContainer = require('../example/DatepickerContainer'),
 	assert = require('assert'),
 	moment = require('moment'),
 	TestUtils = require('react-addons-test-utils')
@@ -24,8 +24,19 @@ var createDatetime = function( props ){
 	return document.getElementById('root').children[0];
 };
 
+var createDatepickerContainer = function( props ){
+	document.body.innerHTML = '<div id="root"></div>';
+
+	ReactDOM.render(
+		React.createElement( DatepickerContainer, props ),
+		document.getElementById('root')
+	);
+
+	return document.getElementById('root').children[0];
+};
+
 var trigger = function( name, element ){
-	var ev = document.createEvent("MouseEvents");
+	var ev = document.createEvent('MouseEvents');
    ev.initEvent(name, true, true);
    element.dispatchEvent( ev );
 };
@@ -455,6 +466,44 @@ describe( 'Datetime', function(){
 		assert.equal(dt.dt().className.indexOf('rdtOpen'), -1);
 		ev.focus( dt.input() );
 		assert.notEqual(dt.dt().className.indexOf('rdtOpen'), -1);
+	});
+
+	it( 'programmatically open picker', function(){
+		createDatepickerContainer({});
+		var container = document.querySelector('.datepicker-container');
+		assert.equal(container.children[0].className.indexOf('rdtOpen'), -1);
+
+		trigger( 'click', document.querySelector('.open-datepicker') );
+		assert.notEqual(container.children[0].className.indexOf('rdtOpen'), -1);
+
+		trigger( 'click', document.querySelector('.open-datepicker') );
+		assert.equal(container.children[0].className.indexOf('rdtOpen'), -1);
+	});
+
+	it( 'close picker on click outside of it, and open it again programmatically', function(){
+		createDatepickerContainer({});
+		var container = document.querySelector('.datepicker-container');
+		assert.equal(container.children[0].className.indexOf('rdtOpen'), -1);
+
+		trigger( 'click', document.querySelector('.open-datepicker') );
+		assert.notEqual(container.children[0].className.indexOf('rdtOpen'), -1);
+
+		trigger( 'mousedown', document.body );
+		assert.equal(container.children[0].className.indexOf('rdtOpen'), -1);
+
+		trigger( 'click', document.querySelector('.open-datepicker') );
+		assert.notEqual(container.children[0].className.indexOf('rdtOpen'), -1);
+	});
+
+	it( 'open picker on first render, then close it programmatically', function(){
+		createDatepickerContainer({
+			open: true
+		});
+		var container = document.querySelector('.datepicker-container');
+		assert.notEqual(container.children[0].className.indexOf('rdtOpen'), -1);
+
+		trigger( 'click', document.querySelector('.open-datepicker') );
+		assert.equal(container.children[0].className.indexOf('rdtOpen'), -1);
 	});
 
 	it( 'onSelect', function( done ){


### PR DESCRIPTION
Workaround to programmatically open/close datepicker

## Description
Change how component checks new props so we can control open prop separately.

## Motivation and Context
This is workaround for issue #44 
This will solve problems with controlling "open" property from outside of datetime component.
Workaround assumes that you have parent container that controls datetime component. (See the example).
You can create controlled component by forwarding control "open" prop to datetime and component will react to prop change.
Also we need feedback when datetime closes itself in order to change our control value in parent component, and for this we can use onBlur function handler in parent component.
This doesn't extend existing API.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change required changes to the documentation.
- - [ ] I have updated the documentation accordingly.
- - [ ] I have updated the TypeScript type definition accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

