### PR TITLE
Fix namespace error for TS typings

### DIFF
--- a/react-datetime.d.ts
+++ b/react-datetime.d.ts
@@ -8,7 +8,6 @@
 //// <reference path="../moment/moment-node.d.ts" />
 
 declare module ReactDatetime {
-  import React = __React;
   // import * as moment from 'moment';
 
   export interface DatetimepickerProps {


### PR DESCRIPTION
@AaronAsAChimp @PeterKottas @vissermc

[Something is broken](https://github.com/YouCanBookMe/react-datetime/issues/215). Is this the change that would make it work? Sorry for having to ask you guys, but I don't have an environment to try it out with.