### PR TITLE
Bug fix for isValiDate

### DIFF
--- a/src/DaysView.js
+++ b/src/DaysView.js
@@ -6,7 +6,6 @@ var React = require('react'),
 
 var DOM = React.DOM;
 var DateTimePickerDays = React.createClass({
-
 	render: function() {
 		var footer = this.renderFooter(),
 			date = this.props.viewDate,
@@ -62,7 +61,7 @@ var DateTimePickerDays = React.createClass({
 			weeks = [],
 			days = [],
 			renderer = this.props.renderDay || this.renderDay,
-			isValid = this.props.isValidDate || this.isValidDate,
+			isValid = this.props.isValidDate || this.alwaysValidDate,
 			classes, disabled, dayProps, currentDate
 		;
 
@@ -130,7 +129,9 @@ var DateTimePickerDays = React.createClass({
 			)
 		);
 	},
-	isValidDate: function(){ return 1; }
+	alwaysValidDate: function(){
+		return 1;
+	}
 });
 
 module.exports = DateTimePickerDays;

--- a/src/MonthsView.js
+++ b/src/MonthsView.js
@@ -6,12 +6,12 @@ var DOM = React.DOM;
 var DateTimePickerMonths = React.createClass({
 	render: function() {
 		return DOM.div({ className: 'rdtMonths' }, [
-			DOM.table({ key: 'a'}, DOM.thead({}, DOM.tr({}, [
-				DOM.th({ key: 'prev', className: 'rdtPrev' }, DOM.span({onClick: this.props.subtractTime(1, 'years')}, '‹')),
-				DOM.th({ key: 'year', className: 'rdtSwitch', onClick: this.props.showView('years'), colSpan: 2, 'data-value': this.props.viewDate.year()}, this.props.viewDate.year() ),
-				DOM.th({ key: 'next', className: 'rdtNext' }, DOM.span({onClick: this.props.addTime(1, 'years')}, '›'))
+			DOM.table({ key: 'a' }, DOM.thead( {}, DOM.tr( {}, [
+				DOM.th({ key: 'prev', className: 'rdtPrev' }, DOM.span({ onClick: this.props.subtractTime( 1, 'years' )}, '‹' )),
+				DOM.th({ key: 'year', className: 'rdtSwitch', onClick: this.props.showView( 'years' ), colSpan: 2, 'data-value': this.props.viewDate.year() }, this.props.viewDate.year() ),
+				DOM.th({ key: 'next', className: 'rdtNext' }, DOM.span({ onClick: this.props.addTime( 1, 'years' )}, '›' ))
 			]))),
-			DOM.table({ key: 'months'}, DOM.tbody({ key: 'b'}, this.renderMonths()))
+			DOM.table({ key: 'months' }, DOM.tbody({ key: 'b' }, this.renderMonths()))
 		]);
 	},
 
@@ -23,20 +23,31 @@ var DateTimePickerMonths = React.createClass({
 			i = 0,
 			months = [],
 			renderer = this.props.renderMonth || this.renderMonth,
-			isValid = this.props.isValidDate || this.isValidDate,
+			isValid = this.props.isValidDate || this.alwaysValidDate,
 			classes, props
 		;
 
-        var currentMonth, disabled,
-            // Date is irrelevant because we're really only interested in month
-            irrelevantDate = 1;
+		var currentMonth, isDisabled, noOfDaysInMonth, daysInMonth, validDay,
+			// Date is irrelevant because we're only interested in month
+			irrelevantDate = 1;
 		while (i < 12) {
 			classes = 'rdtMonth';
 			currentMonth =
-                this.props.viewDate.clone().set({ year: year, month: i, date: irrelevantDate });
-			disabled = !isValid(currentMonth);
+				this.props.viewDate.clone().set({ year: year, month: i, date: irrelevantDate });
 
-			if ( disabled )
+			noOfDaysInMonth = currentMonth.endOf( 'month' ).format( 'D' );
+			daysInMonth = Array.from({ length: noOfDaysInMonth }, function( e, i ) {
+				return i + 1;
+			});
+
+			validDay = daysInMonth.find(function( d ) {
+				var day = currentMonth.clone().set( 'date', d );
+				return isValid( day );
+			});
+
+			isDisabled = ( validDay === undefined );
+
+			if ( isDisabled )
 				classes += ' rdtDisabled';
 
 			if ( date && i === month && year === date.year() )
@@ -48,14 +59,14 @@ var DateTimePickerMonths = React.createClass({
 				className: classes
 			};
 
-			if ( !disabled )
-				props.onClick = (this.props.updateOn === 'months' ?
-                    this.updateSelectedMonth : this.props.setDate('month'));
+			if ( !isDisabled )
+				props.onClick = ( this.props.updateOn === 'months' ?
+					this.updateSelectedMonth : this.props.setDate( 'month' ));
 
 			months.push( renderer( props, i, year, date && date.clone() ));
 
-			if ( months.length === 4 ){
-				rows.push( DOM.tr({ key: month + '_' + rows.length }, months) );
+			if ( months.length === 4 ) {
+				rows.push( DOM.tr({ key: month + '_' + rows.length }, months ) );
 				months = [];
 			}
 
@@ -79,7 +90,7 @@ var DateTimePickerMonths = React.createClass({
 		return DOM.td( props, capitalize( monthStrFixedLength ) );
 	},
 
-	isValidDate: function(){
+	alwaysValidDate: function() {
 		return 1;
 	}
 });

--- a/src/YearsView.js
+++ b/src/YearsView.js
@@ -5,15 +5,15 @@ var React = require('react');
 var DOM = React.DOM;
 var DateTimePickerYears = React.createClass({
 	render: function() {
-		var year = parseInt(this.props.viewDate.year() / 10, 10) * 10;
+		var year = parseInt( this.props.viewDate.year() / 10, 10 ) * 10;
 
 		return DOM.div({ className: 'rdtYears' }, [
-			DOM.table({ key: 'a'}, DOM.thead({}, DOM.tr({}, [
-				DOM.th({ key: 'prev', className: 'rdtPrev' }, DOM.span({onClick: this.props.subtractTime(10, 'years')}, '‹')),
-				DOM.th({ key: 'year', className: 'rdtSwitch', onClick: this.props.showView('years'), colSpan: 2 }, year + '-' + (year + 9) ),
-				DOM.th({ key: 'next', className: 'rdtNext'}, DOM.span({onClick: this.props.addTime(10, 'years')}, '›'))
+			DOM.table({ key: 'a' }, DOM.thead({}, DOM.tr({}, [
+				DOM.th({ key: 'prev', className: 'rdtPrev' }, DOM.span({ onClick: this.props.subtractTime( 10, 'years' )}, '‹' )),
+				DOM.th({ key: 'year', className: 'rdtSwitch', onClick: this.props.showView( 'years' ), colSpan: 2 }, year + '-' + ( year + 9 ) ),
+				DOM.th({ key: 'next', className: 'rdtNext' }, DOM.span({ onClick: this.props.addTime( 10, 'years' )}, '›' ))
 				]))),
-			DOM.table({ key: 'years'}, DOM.tbody({}, this.renderYears( year )))
+			DOM.table({ key: 'years' }, DOM.tbody( {}, this.renderYears( year )))
 		]);
 	},
 
@@ -23,16 +23,16 @@ var DateTimePickerYears = React.createClass({
 			rows = [],
 			renderer = this.props.renderYear || this.renderYear,
 			selectedDate = this.props.selectedDate,
-			isValid = this.props.isValidDate || this.isValidDate,
+			isValid = this.props.isValidDate || this.alwaysValidDate,
 			classes, props
 		;
 
 		year--;
-        var currentYear, disabled,
-            // Month and date are irrelevant here because
-            // we're only really interested in the year
-            irrelevantMonth = 1,
-            irrelevantDate = 1;
+		var currentYear, isDisabled, noOfDaysInYear, daysInYear, validDay,
+			// Month and date are irrelevant here because
+			// we're only interested in the year
+			irrelevantMonth = 0,
+			irrelevantDate = 1;
 		while (i < 11) {
 			classes = 'rdtYear';
 			currentYear = this.props.viewDate.clone().set(
@@ -40,8 +40,19 @@ var DateTimePickerYears = React.createClass({
 			if ( i === -1 | i === 10 )
 				classes += ' rdtOld';
 
-			disabled = !isValid(currentYear);
-			if ( disabled )
+			noOfDaysInYear = currentYear.endOf( 'year' ).format( 'DDD' );
+			daysInYear = Array.from({ length: noOfDaysInYear }, function( e, i ) {
+				return i + 1;
+			});
+
+			validDay = daysInYear.find(function( d ) {
+				var day = currentYear.clone().dayOfYear( d );
+				return isValid( day );
+			});
+
+			isDisabled = ( validDay === undefined );
+
+			if ( isDisabled )
 				classes += ' rdtDisabled';
 
 			if ( selectedDate && selectedDate.year() === year )
@@ -53,7 +64,7 @@ var DateTimePickerYears = React.createClass({
 				className: classes
 			};
 
-			if ( !disabled )
+			if ( !isDisabled )
 				props.onClick = this.props.updateOn === 'years' ? this.updateSelectedYear : this.props.setDate('year');
 
 			years.push( renderer( props, year, selectedDate && selectedDate.clone() ));
@@ -71,14 +82,14 @@ var DateTimePickerYears = React.createClass({
 	},
 
 	updateSelectedYear: function( event ) {
-		this.props.updateSelectedDate(event, true);
+		this.props.updateSelectedDate( event, true );
 	},
 
-	renderYear: function( props, year ){
+	renderYear: function( props, year ) {
 		return DOM.td( props, year );
 	},
 
-	isValidDate: function(){
+	alwaysValidDate: function() {
 		return 1;
 	}
 });

--- a/tests/datetime-spec.js
+++ b/tests/datetime-spec.js
@@ -87,7 +87,8 @@ var date = new Date( 2000, 0, 15, 2, 2, 2, 2 ),
 	mDate = moment( date ),
 	strDate = mDate.format('L') + ' ' + mDate.format('LT'),
 	mDateUTC = moment.utc(date),
-	strDateUTC = mDateUTC.format('L') + ' ' + mDateUTC.format('LT')
+	strDateUTC = mDateUTC.format('L') + ' ' + mDateUTC.format('LT'),
+	currentYear = new Date().getFullYear()
 ;
 
 describe( 'Datetime', function(){
@@ -705,9 +706,8 @@ describe( 'Datetime', function(){
 	});
 
 	it( 'disable months', function(){
-		var yearToday = new Date().getFullYear();
-		var dateBefore = yearToday + '-06-01';
-		createDatetime({ viewMode: 'months', isValidDate: function( current ){
+		var dateBefore = currentYear + '-06-01';
+		createDatetime({ viewMode: 'months', isValidDate: function(current ){
 				return current.isBefore(moment(dateBefore, 'YYYY-MM-DD'));
 		}});
 		assert.equal( dt.month(0).className, 'rdtMonth' );
@@ -717,11 +717,29 @@ describe( 'Datetime', function(){
 	});
 
 	it( 'disable years', function(){
-		createDatetime({ viewMode: 'years', isValidDate: function( current ){
+		createDatetime({ viewMode: 'years', isValidDate: function(current ){
 				return current.isBefore(moment('2016-01-01', 'YYYY-MM-DD'));
 		}});
+		assert.equal( dt.year(0).className, 'rdtYear rdtOld' );
 		assert.equal( dt.year(6).className, 'rdtYear' );
 		assert.equal( dt.year(7).className, 'rdtYear rdtDisabled' );
+	});
+
+	it( 'persistent valid months going monthView->yearView->monthView', function(){
+		var dateBefore = currentYear + '-06-01';
+		createDatetime({ viewMode: 'months', isValidDate: function(current ){
+				return current.isBefore(moment(dateBefore, 'YYYY-MM-DD'));
+		}});
+		assert.equal( dt.month(4).className, 'rdtMonth' );
+		assert.equal( dt.month(5).className, 'rdtMonth rdtDisabled' );
+		// Go to year view
+		ev.click( dt.switcher() );
+		assert.equal( dt.year(0).className, 'rdtYear rdtOld' );
+		assert.equal( dt.year(9).className, 'rdtYear rdtDisabled' );
+		// Go back initial month view, nothing should be changed
+		ev.click( dt.year(8) );
+		assert.equal( dt.month(4).className, 'rdtMonth' );
+		assert.equal( dt.month(5).className, 'rdtMonth rdtDisabled' );
 	});
 
     it( 'locale', function(){


### PR DESCRIPTION
When setting isValidDate and viewMode=month and going from monthView to
yearView and then back the current month was rendered as invalid. This
is now fixed. Plus a bunch of consistency formatting fixes.

This is the fix from PR #198
(https://github.com/YouCanBookMe/react-datetime/pull/198).