### PR TITLE
Disable rdtOld for year view

### DIFF
--- a/src/YearsView.js
+++ b/src/YearsView.js
@@ -36,8 +36,10 @@ var DateTimePickerYears = React.createClass({
 			classes = 'rdtYear';
 			currentYear = this.props.viewDate.clone().set(
 				{ year: year, month: irrelevantMonth, date: irrelevantDate } );
-			if ( i === -1 | i === 10 )
-				classes += ' rdtOld';
+
+			// Not sure what 'rdtOld' is for, commenting out for now as it's not working properly
+			// if ( i === -1 | i === 10 )
+				// classes += ' rdtOld';
 
 			noOfDaysInYear = currentYear.endOf( 'year' ).format( 'DDD' );
 			daysInYear = Array.from({ length: noOfDaysInYear }, function( e, i ) {

--- a/tests/datetime-spec.js
+++ b/tests/datetime-spec.js
@@ -720,7 +720,7 @@ describe( 'Datetime', function(){
 		createDatetime({ viewMode: 'years', isValidDate: function(current ){
 				return current.isBefore(moment('2016-01-01', 'YYYY-MM-DD'));
 		}});
-		assert.equal( dt.year(0).className, 'rdtYear rdtOld' );
+		assert.equal( dt.year(0).className, 'rdtYear' );
 		assert.equal( dt.year(6).className, 'rdtYear' );
 		assert.equal( dt.year(7).className, 'rdtYear rdtDisabled' );
 	});
@@ -734,7 +734,7 @@ describe( 'Datetime', function(){
 		assert.equal( dt.month(5).className, 'rdtMonth rdtDisabled' );
 		// Go to year view
 		ev.click( dt.switcher() );
-		assert.equal( dt.year(0).className, 'rdtYear rdtOld' );
+		assert.equal( dt.year(0).className, 'rdtYear' );
 		assert.equal( dt.year(9).className, 'rdtYear rdtDisabled' );
 		// Go back initial month view, nothing should be changed
 		ev.click( dt.year(8) );


### PR DESCRIPTION
It was not working properly, not sure what it's for. Oldest commit I can trace it back to is this one: https://github.com/YouCanBookMe/react-datetime/commit/d76f7b08bc6bbc4f8a72327400c1ff0739330459

So it might be a left over for when forking from the original repo. Will keep it in the code base for now.