### PR TITLE
Fixup typings for react 15.4.2, typescript 2.1.4

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5,6 +5,8 @@
 
 declare module 'react-datetime' {
 
+  import React = __React;
+
   /*
    A stand-in type for Moment, this file currently has no way of guaranteeing
    the existence of those typings.


### PR DESCRIPTION
### Description
Added `import React = __React;` to index.d.ts (2.x typings)
Fixes issue #248

### Motivation and Context
Solves issue with tsc compile when using react 15.4.2 and typescript 2.1.4

### Checklist
```
[ ] I have added tests covering my changes
[X ] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```