### PR TITLE
Respect closeOnSelect property

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -161,8 +161,13 @@ var Datetime = React.createClass({
 			updatedState = this.getStateFromProps( nextProps );
 		}
 
+		// What is this for? Keeping for now, will remove later
 		if ( updatedState.open === undefined ) {
 			updatedState.open = this.state.open;
+		}
+
+		if ( this.props.closeOnSelect === false ) {
+			updatedState.open = true;
 		}
 
 		if ( nextProps.viewMode !== this.props.viewMode ) {


### PR DESCRIPTION
This logic was lost in a previous commit, hopefully this new check will
be enough to cover all the cases as well as not ruining any others. I
did not manage to write a test for this as it required props I do not
know how to mock to be able to reproduce.