### PR TITLE
Fix/months view active month

### DIFF
--- a/src/MonthsView.js
+++ b/src/MonthsView.js
@@ -51,7 +51,7 @@ var DateTimePickerMonths = onClickOutside( React.createClass({
 			if ( isDisabled )
 				classes += ' rdtDisabled';
 
-			if ( date && i === month && year === date.year() )
+			if ( date && i === date.month() && year === date.year() )
 				classes += ' rdtActive';
 
 			props = {

--- a/tests/datetime.spec.js
+++ b/tests/datetime.spec.js
@@ -255,7 +255,7 @@ describe('Datetime', () => {
 		expect(component.find('.rdtDay.rdtToday').text()).toEqual('19');
 	});
 
-	// Proof of bug
+	// Proof of bug [FIXED]
 	it('should show correct selected month when traversing view modes', () => {
 		const date = new Date(2000, 4, 3, 2, 2, 2, 2),
 			component = utils.createDatetime({ viewMode: 'days', defaultValue: date });
@@ -275,7 +275,7 @@ describe('Datetime', () => {
 		utils.clickNthYear(component, 1);
 
 		// The selected month is now _January_
-		expect(component.find('.rdtMonth .rdtActive').text()).toEqual('Jan');
+		expect(component.find('.rdtMonth .rdtActive').text()).toEqual('May');
 	});
 
 	describe('with custom props', () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the *Title* above -->

### Description
I was having the same issue as #289. The active month wasn't highlighting correctly.. was always showing December as active.

### Motivation and Context
fixes issue #289

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[x] I have added tests covering my changes
[x] All new and existing tests pass - 2 were failing on master.. those are still failing
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
