### PR TITLE
if isValidDate is passed we need to verify if the view date is valid …

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -191,10 +191,10 @@ var Datetime = React.createClass({
 			}
 		}
 		//we should only show a valid date if we are provided a isValidDate function.
-		if(this.props.isValidDate){
+		if (this.props.isValidDate) {
 			updatedState.viewDate = updatedState.viewDate || this.state.viewDate;
-			while(!this.props.isValidDate(updatedState.viewDate)){
-				updatedState.viewDate = updatedState.viewDate.add(1, "day");
+			while (!this.props.isValidDate(updatedState.viewDate)) {
+				updatedState.viewDate = updatedState.viewDate.add(1, 'day');
 			}
 		}
 		this.setState( updatedState );

--- a/DateTime.js
+++ b/DateTime.js
@@ -190,7 +190,13 @@ var Datetime = React.createClass({
 				}
 			}
 		}
-
+		//we should only show a valid date if we are provided a isValidDate function.
+		if(this.props.isValidDate){
+			updatedState.viewDate = updatedState.viewDate || this.state.viewDate;
+			while(!this.props.isValidDate(updatedState.viewDate)){
+				updatedState.viewDate = updatedState.viewDate.add(1, "day");
+			}
+		}
 		this.setState( updatedState );
 	},
 


### PR DESCRIPTION
…before trying to render the component.

The calendar should only show a date that is selectable (based on isValidDate function)

### Description
added some code to check isValidDate to change the viewDate to a date that can actually be selected. 

### Motivation and Context
My users were complaining that when there was a range that was disabled on the current month they would have to skip to the month where dates are selectable. This will now do this automatically.

### Checklist

```
[ ] I have added tests covering my changes
[ ] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


