### PR TITLE
Fix typescript definitions for 'value'

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -34,12 +34,12 @@ declare module 'react-datetime' {
      Represents the selected date by the component, in order to use it as a controlled component.
      This prop is parsed by moment.js, so it is possible to use a date string or a moment.js date.
      */
-    value?: Date;
+    value?: Date | string | Moment;
     /*
      Represents the selected date for the component to use it as a uncontrolled component.
      This prop is parsed by moment.js, so it is possible to use a date string or a moment.js date.
      */
-    defaultValue?: Date;
+    defaultValue?: Date | string | Moment;
     /*
      Defines the format for the date. It accepts any moment.js date format.
      If true the date will be displayed using the defaults for the current locale.

--- a/typings/react-datetime-tests.tsx
+++ b/typings/react-datetime-tests.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Moment } from 'moment';
+import * as moment from 'moment';
 import * as ReactDatetime from 'react-datetime';
 
 /*
@@ -15,11 +16,23 @@ const TEST_BASIC_USAGE: JSX.Element = <ReactDatetime />;
 const TEST_DATE_PROPS_FOR_VALUE: JSX.Element = <ReactDatetime
 		value={ new Date() }
 	/>;
+const TEST_DATE_PROPS_FOR_VALUE_AS_MOMENT: JSX.Element = <ReactDatetime
+		value={ moment() }
+	/>;
+const TEST_DATE_PROPS_FOR_VALUE_AS_STRING: JSX.Element = <ReactDatetime
+		value={ '1995-12-25' }
+	/>;
+
 
 const TEST_DATE_PROPS_FOR_DEFAULT_VALUE: JSX.Element = <ReactDatetime
 		defaultValue={ new Date() }
 	/>;
-
+const TEST_DATE_PROPS_FOR_DEFAULT_VALUE_AS_MOMENT: JSX.Element = <ReactDatetime
+		defaultValue={ moment() }
+	/>;
+const TEST_DATE_PROPS_FOR_DEFAULT_VALUE_AS_STRING: JSX.Element = <ReactDatetime
+		defaultValue={ '1995-12-25' }
+	/>;
 /*
  Test formats
  */


### PR DESCRIPTION
### Description
Typescript definitions for 'value' were previous locked to Date - this updates them to Date, Moment, or string, as specified in the docs

### Motivation and Context
Our company uses the react-datetime in a React + Typescript environment and we pass in momentjs objects. This is valid behaviour and works, but the type definitions currently raise errors unless we convert the momentjs back to Javascript Date objects... which is a waste seeing as they will be parsed by Moment again inside the component.

### Checklist

- [x] I have added tests covering my changes
- [x] All new and existing tests pass
- [x] My changes required the documentation to be updated (Not applicable - documentation was already correct!)
-   [x] I have updated the documentation accordingly (N/A - see above)
-   [ ] I have updated the TypeScript 1.8 type definitions accordingly
    Not sure what to do here. Can't verify that the Moment type will be available in the TS1.8 environment
-   [x] I have updated the TypeScript 2.0+ type definitions accordingly


