### PR TITLE
Disable context menu in timepicker's up & down arrow

### DIFF
--- a/src/TimeView.js
+++ b/src/TimeView.js
@@ -57,9 +57,9 @@ var DateTimePickerTime = onClickOutside( React.createClass({
 				}
 			}
 			return DOM.div({ key: type, className: 'rdtCounter' }, [
-				DOM.span({ key: 'up', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'increase', type ) }, '▲' ),
+				DOM.span({ key: 'up', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'increase', type ), onContextMenu: this.disableContextMenu }, '▲' ),
 				DOM.div({ key: 'c', className: 'rdtCount' }, value ),
-				DOM.span({ key: 'do', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'decrease', type ) }, '▼' )
+				DOM.span({ key: 'do', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'decrease', type ), onContextMenu: this.disableContextMenu }, '▼' )
 			]);
 		}
 		return '';
@@ -67,9 +67,9 @@ var DateTimePickerTime = onClickOutside( React.createClass({
 
 	renderDayPart: function() {
 		return DOM.div({ key: 'dayPart', className: 'rdtCounter' }, [
-			DOM.span({ key: 'up', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'toggleDayPart', 'hours') }, '▲' ),
+			DOM.span({ key: 'up', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'toggleDayPart', 'hours'), onContextMenu: this.disableContextMenu }, '▲' ),
 			DOM.div({ key: this.state.daypart, className: 'rdtCount' }, this.state.daypart ),
-			DOM.span({ key: 'do', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'toggleDayPart', 'hours') }, '▼' )
+			DOM.span({ key: 'do', className: 'rdtBtn', onMouseDown: this.onStartClicking( 'toggleDayPart', 'hours'), onContextMenu: this.disableContextMenu }, '▼' )
 		]);
 	},
 
@@ -183,6 +183,11 @@ var DateTimePickerTime = onClickOutside( React.createClass({
 
 			document.body.addEventListener( 'mouseup', me.mouseUpListener );
 		};
+	},
+
+	disableContextMenu: function(event) {
+		event.preventDefault();
+		return false;
 	},
 
 	padValues: {


### PR DESCRIPTION
Right now, right clicking on up or down arrow starts the counter while also showing the default context menu for browsers. This commit disables the context menu & makes the right click behavior identical to left click.