### PR TITLE
Open calendar when clicking on input

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -414,6 +414,7 @@ var Datetime = createClass({
 				type: 'text',
 				className: 'form-control',
 				onFocus: this.openCalendar,
+				onClick: this.openCalendar,
 				onChange: this.onInputChange,
 				onKeyDown: this.onInputKey,
 				value: this.state.inputValue

--- a/tests/datetime.spec.js
+++ b/tests/datetime.spec.js
@@ -196,6 +196,12 @@ describe('Datetime', () => {
 		expect(utils.isOpen(component)).toBeTruthy();
 	});
 
+	it('opens picker when clicking on input', () => {
+		const component = utils.createDatetime();
+		component.find('.form-control').simulate('click');
+		expect(utils.isOpen(component)).toBeTruthy();
+	});
+
 	it('sets CSS class on selected item (day)', () => {
 		const component = utils.createDatetime({ viewMode: 'days' });
 		utils.openDatepicker(component);


### PR DESCRIPTION
Fixes #322

<!-- Provide a general summary of your changes in the *Title* above -->

### Description

input.onClick will call openCalendar.

### Motivation and Context

Right now the user can't reopen the calendar without refocussing. This is unintuitive.

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[*] I have added tests covering my changes
[*] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
