### PR TITLE
Make number of weeks in "days view" fluid, fixes #279

### DIFF
--- a/src/DaysView.js
+++ b/src/DaysView.js
@@ -67,9 +67,22 @@ var DateTimePickerDays = onClickOutside( createClass({
 			classes, isDisabled, dayProps, currentDate
 		;
 
-		// Go to the last week of the previous month
-		prevMonth.date( prevMonth.daysInMonth() ).startOf( 'week' );
-		var lastDay = prevMonth.clone().add( 42, 'd' );
+    // Go to the last week of the previous month
+    prevMonth.date( prevMonth.daysInMonth() );
+    // Prepend one calendar week if the month doesn't start at week start (Monday/Sunday)
+    if (prevMonth.weekday() === moment().endOf('week').weekday()) {
+      prevMonth.endOf( 'week' );
+    } else {
+      prevMonth.startOf( 'week' );
+    }
+
+    var lastDay = date.clone().date( date.daysInMonth() );
+    // Append one extra calendar week only if the month doesn't end at week end (Sunday/Saturday)
+    if (lastDay.weekday() !== moment().endOf('week').weekday()) {
+      lastDay.add( 1, 'weeks' );
+    }
+    // Needed to include the whole last day of the month
+    lastDay.add( 1, 'd' );
 
 		while ( prevMonth.isBefore( lastDay ) ) {
 			classes = 'rdtDay';

--- a/src/DaysView.js
+++ b/src/DaysView.js
@@ -1,9 +1,9 @@
 'use strict';
 
 var React = require('react'),
-    createClass = require('create-react-class'),
+		createClass = require('create-react-class'),
 	moment = require('moment'),
-  onClickOutside = require('react-onclickoutside')
+	onClickOutside = require('react-onclickoutside')
 ;
 
 var DOM = React.DOM;
@@ -67,22 +67,24 @@ var DateTimePickerDays = onClickOutside( createClass({
 			classes, isDisabled, dayProps, currentDate
 		;
 
-    // Go to the last week of the previous month
-    prevMonth.date( prevMonth.daysInMonth() );
-    // Prepend one calendar week if the month doesn't start at week start (Monday/Sunday)
-    if (prevMonth.weekday() === moment().endOf('week').weekday()) {
-      prevMonth.endOf( 'week' );
-    } else {
-      prevMonth.startOf( 'week' );
-    }
+		// Go to the last week of the previous month
+		prevMonth.date( prevMonth.daysInMonth() );
+		// Prepend one calendar week if the month doesn't start at week start (Monday/Sunday)
+		if (prevMonth.weekday() === moment().endOf('week').weekday()) {
+			prevMonth.endOf( 'week' );
+			// Needed to account for the whole last day of the previous month
+			prevMonth.add( 1, 'd' );
+		} else {
+			prevMonth.startOf( 'week' );
+		}
 
-    var lastDay = date.clone().date( date.daysInMonth() );
-    // Append one extra calendar week only if the month doesn't end at week end (Sunday/Saturday)
-    if (lastDay.weekday() !== moment().endOf('week').weekday()) {
-      lastDay.add( 1, 'weeks' );
-    }
-    // Needed to include the whole last day of the month
-    lastDay.add( 1, 'd' );
+		var lastDay = date.clone().date( date.daysInMonth() );
+		// Append one extra calendar week only if the month doesn't end at week end (Sunday/Saturday)
+		if (lastDay.weekday() !== moment().endOf('week').weekday()) {
+			lastDay.add( 1, 'weeks' );
+		}
+		// Needed to account for the whole last day of the current month
+		lastDay.add( 1, 'd' );
 
 		while ( prevMonth.isBefore( lastDay ) ) {
 			classes = 'rdtDay';
@@ -150,9 +152,9 @@ var DateTimePickerDays = onClickOutside( createClass({
 		return 1;
 	},
 
-  handleClickOutside: function() {
-    this.props.handleClickOutside();
-  }
+	handleClickOutside: function() {
+		this.props.handleClickOutside();
+	}
 }));
 
 module.exports = DateTimePickerDays;

--- a/tests/datetime.spec.js
+++ b/tests/datetime.spec.js
@@ -234,14 +234,16 @@ describe('Datetime', () => {
 	});
 
 	it('selected day persists (in UI) when navigating to prev month', () => {
-		const date = new Date(2000, 0, 3, 2, 2, 2, 2),
+		const date = new Date(2000, 0, 1, 2, 2, 2, 2),
 			component = utils.createDatetime({ viewMode: 'days', defaultValue: date });
 
 		utils.openDatepicker(component);
-		expect(utils.getNthDay(component, 8).hasClass('rdtActive')).toBeTruthy();
+		expect(utils.getNthDay(component, 6).hasClass('rdtActive')).toBeTruthy();
+		let dayNumber = utils.getNthDay(component, 6).text();
 		// Go to previous month
 		utils.clickOnElement(component.find('.rdtDays .rdtPrev span'));
-		expect(utils.getNthDay(component, 36).hasClass('rdtActive')).toBeTruthy();
+
+		expect(utils.getActiveDay(component).text() === dayNumber).toBeTruthy();
 	});
 
 	it('sets CSS class on today date', () => {
@@ -388,7 +390,7 @@ describe('Datetime', () => {
 			const component = utils.createDatetime({ value: mDate, renderDay: renderDayFn });
 
 			// Last day should be 6th of february
-			expect(currentDate.day()).toEqual(6);
+			expect(currentDate.day()).toEqual(1);
 			expect(currentDate.month()).toEqual(1);
 
 			// The date must be the same

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -98,6 +98,10 @@ module.exports = {
 		return datetime.find('.rdtDay').at(n);
 	},
 
+	getActiveDay: (datetime) => {
+		return datetime.find('.rdtDay.rdtActive');
+	},
+
 	getNthMonth: (datetime, n) => {
 		return datetime.find('.rdtMonth').at(n);
 	},


### PR DESCRIPTION
### Description
Currently, the number of weeks in "days view" is fixed to 5 which causes most months to either have a whole week from the previous month or from the following month being rendered. This is unusual in most calendar UIs.
This change checks if the previous and current months end on the last day of the week (depends on the locale set in momentJS) to decide if an extra week is necessary.
This also fixes tests to take this change into account.

So this:
![image](https://cloud.githubusercontent.com/assets/2715751/25898541/d8ff7b06-358c-11e7-9279-39b9168da2c4.png)

Becomes this:
![image](https://cloud.githubusercontent.com/assets/2715751/25898558/eb8533a6-358c-11e7-9638-3be101ec19c1.png)

And this:
![image](https://cloud.githubusercontent.com/assets/2715751/25898594/102635ac-358d-11e7-90dd-f2c9db9cd54e.png)

Becomes this:
![image](https://cloud.githubusercontent.com/assets/2715751/25900131/ab0118ee-3592-11e7-9ca7-bfb64027d23a.png)


### Motivation and Context
Fixes #279 

### Checklist

[x] I have added (changed) tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated

_Please let me know if this is something you would like to see merged. It would be useful to me. I have some more time I can pour into this if you think I should parametrize this instead because this has the side effect of changing the widget height._