### PR TITLE
Allow AM/PM format without preceding space

### DIFF
--- a/src/TimeView.js
+++ b/src/TimeView.js
@@ -29,8 +29,8 @@ var DateTimePickerTime = onClickOutside( createClass({
 		}
 
 		var daypart = false;
-		if ( this.state !== null && this.props.timeFormat.toLowerCase().indexOf( ' a' ) !== -1 ) {
-			if ( this.props.timeFormat.indexOf( ' A' ) !== -1 ) {
+		if ( this.state !== null && this.props.timeFormat.toLowerCase().indexOf( 'a' ) !== -1 ) {
+			if ( this.props.timeFormat.indexOf( 'A' ) !== -1 ) {
 				daypart = ( this.state.hours >= 12 ) ? 'PM' : 'AM';
 			} else {
 				daypart = ( this.state.hours >= 12 ) ? 'pm' : 'am';

--- a/tests/datetime.spec.js
+++ b/tests/datetime.spec.js
@@ -336,6 +336,13 @@ describe('Datetime', () => {
 			expect(utils.getInputValue(component)).toEqual(expect.stringMatching('.*AM$'));
 		});
 
+		it('timeFormat with no space between the time string and A', () => {
+			const date = new Date(2000, 0, 15, 2, 2, 2, 2),
+				format = 'HH:mm:ss:SSSA',
+				component = utils.createDatetime({ value: date, timeFormat: format });
+			expect(utils.getInputValue(component)).toEqual(expect.stringMatching('.*AM$'));
+		});
+
 		it('viewMode=years', () => {
 			const component = utils.createDatetime({ viewMode: 'years' });
 			expect(utils.isYearView(component)).toBeTruthy();


### PR DESCRIPTION
### Description
Time strings containing `a` or `A` without a preceding space will display 24h format in the dropdown box.

`hh:mm A` works as expected.
`hh:mmA` displays 24h format.

### Motivation and Context
I checked `moment`'s formatting strings, and there are no `A`'s anywhere else, so this appears to be safe to merge: https://momentjs.com/docs/#/displaying/format/

### Checklist
```
[x] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```

Thanks.