### PR TITLE
Add create-react-class dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "webpack-stream": "^3.2.0"
   },
   "dependencies": {
+    "create-react-class": "^15.5.2",
     "@types/react": ">=15",
     "object-assign": "^3.0.0",
     "prop-types": "^15.5.7",


### PR DESCRIPTION
It was added in commit https://github.com/YouCanBookMe/react-datetime/commit/84755ceb54dd6f5fe7682912336b243e4b7dc59b but then remove in this commit https://github.com/YouCanBookMe/react-datetime/commit/752fa8b2aee6385115c86d74e8f641de48982323 for no obvious reason. Apparently it's causing some problems for people (https://github.com/YouCanBookMe/react-datetime/issues/399) so adding it back.
