### PR TITLE
Added support for "disableOnClickOutside" property.

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -347,7 +347,7 @@ var Datetime = createClass({
 	},
 
 	handleClickOutside: function() {
-		if ( this.props.input && this.state.open && !this.props.open ) {
+		if ( this.props.input && this.state.open && !this.props.open && !this.props.disableOnClickOutside ) {
 			this.setState({ open: false }, function() {
 				this.props.onBlur( this.state.selectedDate || this.state.inputValue );
 			});

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -522,6 +522,28 @@ describe('Datetime', () => {
 			expect(utils.isOpen(component)).toBeTruthy();
 		});
 
+		it('disableOnClickOutside=true', () => {
+			const date = new Date(2000, 0, 15, 2, 2, 2, 2),
+				component = utils.createDatetime({ value: date, disableOnClickOutside: true });
+
+			expect(utils.isOpen(component)).toBeFalsy();
+			utils.openDatepicker(component);
+			expect(utils.isOpen(component)).toBeTruthy();
+			document.dispatchEvent(new Event('mousedown'));
+			expect(utils.isOpen(component)).toBeTruthy();
+		});
+
+    it('disableOnClickOutside=false', () => {
+			const date = new Date(2000, 0, 15, 2, 2, 2, 2),
+				component = utils.createDatetime({ value: date, disableOnClickOutside: false });
+
+			expect(utils.isOpen(component)).toBeFalsy();
+			utils.openDatepicker(component);
+			expect(utils.isOpen(component)).toBeTruthy();
+			document.dispatchEvent(new Event('mousedown'));
+			expect(utils.isOpen(component)).toBeFalsy();
+		});
+
 		it('increase time', () => {
 			let i = 0;
 			const date = new Date(2000, 0, 15, 2, 2, 2, 2),

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -530,6 +530,7 @@ describe('Datetime', () => {
 			utils.openDatepicker(component);
 			expect(utils.isOpen(component)).toBeTruthy();
 			document.dispatchEvent(new Event('mousedown'));
+			component.update();
 			expect(utils.isOpen(component)).toBeTruthy();
 		});
 
@@ -541,6 +542,7 @@ describe('Datetime', () => {
 			utils.openDatepicker(component);
 			expect(utils.isOpen(component)).toBeTruthy();
 			document.dispatchEvent(new Event('mousedown'));
+			component.update();
 			expect(utils.isOpen(component)).toBeFalsy();
 		});
 


### PR DESCRIPTION
Added functionality to do not close calendar when `disableOnClickOutside` is set to true.

### Description
<!-- Describe your changes in detail -->

### Motivation and Context
This pull request fixes bug #402, adding support for `disableOnClickOutside` documented property.

### Checklist
```
[X] I have added tests covering my changes
[X] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```