### PR TITLE
Use correct types for props value & defaultValue

### DIFF
--- a/DateTime.d.ts
+++ b/DateTime.d.ts
@@ -35,24 +35,24 @@ declare namespace ReactDatetimeClass {
          Represents the selected date by the component, in order to use it as a controlled component.
          This prop is parsed by moment.js, so it is possible to use a date string or a moment.js date.
          */
-        value?: Date;
+        value?: Date | string | Moment;
         /*
          Represents the selected date for the component to use it as a uncontrolled component.
          This prop is parsed by moment.js, so it is possible to use a date string or a moment.js date.
          */
-        defaultValue?: Date;
+        defaultValue?: Date | string | Moment;
         /*
          Defines the format for the date. It accepts any moment.js date format.
          If true the date will be displayed using the defaults for the current locale.
          If false the datepicker is disabled and the component can be used as timepicker.
          */
-        dateFormat?: boolean|string;
+        dateFormat?: boolean | string;
         /*
          Defines the format for the time. It accepts any moment.js time format.
          If true the time will be displayed using the defaults for the current locale.
          If false the timepicker is disabled and the component can be used as datepicker.
          */
-        timeFormat?: boolean|string;
+        timeFormat?: boolean | string;
         /*
          Whether to show an input field to edit the date manually.
          */
@@ -96,7 +96,7 @@ declare namespace ReactDatetimeClass {
         /*
          The default view to display when the picker is shown. ('years', 'months', 'days', 'time')
          */
-        viewMode?: ViewMode|number;
+        viewMode?: ViewMode | number;
         /*
          Extra class names for the component markup.
          */


### PR DESCRIPTION
The changed props definitions actually accept more than just a JS date
object, and the TS definition should reflect this. Fixes #336.
