### PR TITLE
Fix open prop

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -152,7 +152,9 @@ var Datetime = createClass({
 		}
 
 		if ( updatedState.open === undefined ) {
-			if ( this.props.closeOnSelect && this.state.currentView !== 'time' ) {
+			if ( typeof nextProps.open !== 'undefined' ) {
+				updatedState.open = nextProps.open;
+			} else if ( this.props.closeOnSelect && this.state.currentView !== 'time' ) {
 				updatedState.open = false;
 			} else {
 				updatedState.open = this.state.open;

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -97,6 +97,18 @@ describe('Datetime', () => {
 		expect(utils.isYearView(component)).toBeTruthy();
 	});
 
+	it('toggles calendar when open prop changes', () => {
+		const component = utils.createDatetime({ open: false });
+		expect(utils.isOpen(component)).toBeFalsy();
+		// expect(component.find('.rdtOpen').length).toEqual(0);
+		component.setProps({ open: true });
+		expect(utils.isOpen(component)).toBeTruthy();
+		// expect(component.find('.rdtOpen').length).toEqual(1);
+		component.setProps({ open: false });
+		expect(utils.isOpen(component)).toBeFalsy();
+		// expect(component.find('.rdtOpen').length).toEqual(0);
+	});
+
 	it('selectYear', () => {
 		const date = new Date(2000, 0, 15, 2, 2, 2, 2),
 			component = utils.createDatetime({ viewMode: 'years', defaultValue: date });


### PR DESCRIPTION
The `open` prop has been broken for as long as I've been involved in this project, and this change seems to fix it. Now it actually does what it supposed to, it sets the open/closed state of the datepicker.

It's always scary to change the core logic of the component, but I'm so fed up with seeing this issue being reported so I'm just gonna try this code change and see if it works.