### PR TITLE
FEATURE: add a snap flag to enable snapping to plausible steps on inc & dec in TimeView

### DIFF
--- a/DateTime.d.ts
+++ b/DateTime.d.ts
@@ -16,9 +16,9 @@ declare namespace ReactDatetimeClass {
     export type ViewMode = "years" | "months" | "days" | "time";
 
     export interface TimeConstraint {
-        min: number;
-        max: number;
-        step: number;
+        min?: number;
+        max?: number;
+        step?: number;
     }
 
     export interface TimeConstraints {
@@ -170,6 +170,10 @@ declare namespace ReactDatetimeClass {
          close it.
          */
         disableOnClickOutside?: boolean;
+        /*
+         Enables snapping to the relevant value on increase/decrease based on step.
+         */
+        snap?: boolean;
     }
 
     export interface DatetimepickerState {

--- a/DateTime.js
+++ b/DateTime.js
@@ -42,7 +42,8 @@ var Datetime = createClass({
 		open: TYPES.bool,
 		strictParsing: TYPES.bool,
 		closeOnSelect: TYPES.bool,
-		closeOnTab: TYPES.bool
+		closeOnTab: TYPES.bool,
+		snap: TYPES.bool,
 	},
 
 	getInitialState: function() {
@@ -416,7 +417,7 @@ var Datetime = createClass({
 	},
 
 	componentProps: {
-		fromProps: ['value', 'isValidDate', 'renderDay', 'renderMonth', 'renderYear', 'timeConstraints'],
+		fromProps: ['value', 'isValidDate', 'renderDay', 'renderMonth', 'renderYear', 'timeConstraints', 'snap'],
 		fromState: ['viewDate', 'selectedDate', 'updateOn'],
 		fromThis: ['setDate', 'setTime', 'showView', 'addTime', 'subtractTime', 'updateSelectedDate', 'localMoment', 'handleClickOutside']
 	},

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ render: function() {
 | **closeOnTab** | `boolean` | `true` | When `true` and the input is focused, pressing the `tab` key will close the datepicker.
 | **timeConstraints** | `object` | `null` | Add some constraints to the timepicker. It accepts an `object` with the format `{ hours: { min: 9, max: 15, step: 2 }}`, this example means the hours can't be lower than `9` and higher than `15`, and it will change adding or subtracting `2` hours everytime the buttons are clicked. The constraints can be added to the `hours`, `minutes`, `seconds` and `milliseconds`.
 | **disableCloseOnClickOutside** | `boolean` | `false` | When `true`, keep the datepicker open when click event is triggered outside of component. When `false`, close it.
+| **snap** | `boolean` | `false` | When `true`, in `TimeView`: increasing/decreasing a value (hour, minute, etc) would snap to the next/previous _plausible_ value (determined by `step` in `TimeConstrains`) Example: consider `value: 12` and `step: 5`; increasing the value would snap to `15` instead of `17` and decreasing would snap to `10` instead of `7`. When `false`, default behavior (just add/substract the `step` value from the current `value`).
 
 ## i18n
 Different language and date formats are supported by react-datetime. React uses [Moment.js](http://momentjs.com/) to format the dates, and the easiest way of changing the language of the calendar is [changing the Moment.js locale](http://momentjs.com/docs/#/i18n/changing-locale/).

--- a/react-datetime.d.ts
+++ b/react-datetime.d.ts
@@ -157,6 +157,10 @@ declare module ReactDatetime {
      close it.
     */
     disableOnClickOutside?: boolean;
+    /*
+     Enables snapping to the relevant value on increase/decrease based on step.
+    */
+    snap?: boolean;
   }
 
   interface DatetimeComponent extends React.ComponentClass<DatetimepickerProps> {

--- a/src/TimeView.js
+++ b/src/TimeView.js
@@ -201,24 +201,42 @@ var DateTimePickerTime = createClass({
 	},
 
 	toggleDayPart: function( type ) { // type is always 'hours'
-		var value = parseInt( this.state[ type ], 10) + 12;
+		var value = parseInt( this.state[ type ], 10 ) + 12;
 		if ( value > this.timeConstraints[ type ].max )
 			value = this.timeConstraints[ type ].min + ( value - ( this.timeConstraints[ type ].max + 1 ) );
 		return this.pad( type, value );
 	},
 
 	increase: function( type ) {
-		var value = parseInt( this.state[ type ], 10) + this.timeConstraints[ type ].step;
-		if ( value > this.timeConstraints[ type ].max )
-			value = this.timeConstraints[ type ].min + ( value - ( this.timeConstraints[ type ].max + 1 ) );
-		return this.pad( type, value );
+		var step = this.timeConstraints[ type ].step;
+		var previousValue = parseInt( this.state[ type ], 10 );
+		var isSnapEnabled = Boolean( this.props.snap );
+
+		var nextValue = ( isSnapEnabled && previousValue % step !== 0 && step > 1 ) ?
+			previousValue + ( step - previousValue % step ) :
+			previousValue + step;
+		
+		if ( nextValue > this.timeConstraints[ type ].max ) {
+			nextValue = this.timeConstraints[ type ].min + ( nextValue - ( this.timeConstraints[ type ].max + 1 ) );
+		}
+		
+		return this.pad( type, nextValue );
 	},
 
 	decrease: function( type ) {
-		var value = parseInt( this.state[ type ], 10) - this.timeConstraints[ type ].step;
-		if ( value < this.timeConstraints[ type ].min )
-			value = this.timeConstraints[ type ].max + 1 - ( this.timeConstraints[ type ].min - value );
-		return this.pad( type, value );
+		var step = this.timeConstraints[ type ].step;
+		var previousValue = parseInt( this.state[ type ], 10 );
+		var isSnapEnabled = Boolean( this.props.snap );
+		
+		var nextValue = ( isSnapEnabled && previousValue % step !== 0 && step > 1 ) ?
+			previousValue - ( previousValue % step ) :
+			previousValue - step;
+		
+		if ( nextValue < this.timeConstraints[ type ].min ) {
+			nextValue = this.timeConstraints[ type ].max + 1 - ( this.timeConstraints[ type ].min - nextValue );
+		}
+		
+		return this.pad( type, nextValue );
 	},
 
 	pad: function( type, value ) {

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -512,7 +512,7 @@ describe('Datetime', () => {
 			expect(utils.isOpen(component)).toBeTruthy();
 		});
 
-    it('disableCloseOnClickOutside=false', () => {
+		it('disableCloseOnClickOutside=false', () => {
 			const date = new Date(2000, 0, 15, 2, 2, 2, 2),
 				component = utils.createDatetime({ value: date, disableCloseOnClickOutside: false });
 
@@ -556,6 +556,43 @@ describe('Datetime', () => {
 			expect(utils.getSeconds(component)).toEqual('03');
 		});
 
+		it('should snap to next plausible step on increase with snap enabled', () => {
+			const component = utils.createDatetime({
+				snap: true,
+				timeFormat: 'HH:mm:ss:SSS', 
+				viewMode: 'time',
+				defaultValue: new Date(2000, 0, 15, 2, 2, 50, 2), 
+				timeConstraints: {
+					hours: {
+						step: 2
+					},
+					minutes: {
+						step: 5
+					},
+					seconds: {
+						step: 15
+					},
+					milliseconds: {
+						step: 100
+					}
+				},
+			});
+
+			expect(utils.getHours(component)).toEqual('2');
+			utils.increaseHour(component);
+			expect(utils.getHours(component)).toEqual('4');
+			
+			expect(utils.getMinutes(component)).toEqual('02');
+			utils.increaseMinute(component);
+			expect(utils.getMinutes(component)).toEqual('05');
+			
+			expect(utils.getSeconds(component)).toEqual('50');
+			utils.increaseSecond(component);
+			expect(utils.getSeconds(component)).toEqual('00');
+			utils.increaseSecond(component);
+			expect(utils.getSeconds(component)).toEqual('15');
+		});
+
 		it('decrease time', () => {
 			let i = 0;
 			const date = new Date(2000, 0, 15, 2, 2, 2, 2),
@@ -586,6 +623,43 @@ describe('Datetime', () => {
 			expect(utils.getSeconds(component)).toEqual('02');
 			utils.decreaseSecond(component);
 			expect(utils.getSeconds(component)).toEqual('01');
+		});
+
+		it('should snap to previews plausible step on decrease with snap enabled', () => {
+			const component = utils.createDatetime({
+				snap: true,
+				timeFormat: 'HH:mm:ss:SSS', 
+				viewMode: 'time',
+				defaultValue: new Date(2000, 0, 15, 5, 2, 2, 2), 
+				timeConstraints: {
+					hours: {
+						step: 2
+					},
+					minutes: {
+						step: 5
+					},
+					seconds: {
+						step: 15
+					},
+					milliseconds: {
+						step: 100
+					}
+				},
+			});
+
+			expect(utils.getHours(component)).toEqual('5');
+			utils.decreaseHour(component);
+			expect(utils.getHours(component)).toEqual('4');
+			
+			expect(utils.getMinutes(component)).toEqual('02');
+			utils.decreaseMinute(component);
+			expect(utils.getMinutes(component)).toEqual('00');
+			
+			expect(utils.getSeconds(component)).toEqual('02');
+			utils.decreaseSecond(component);
+			expect(utils.getSeconds(component)).toEqual('00');
+			utils.decreaseSecond(component);
+			expect(utils.getSeconds(component)).toEqual('45');
 		});
 
 		it('long increase time', (done) => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the *Title* above -->

### Description
<!-- Describe your changes in detail -->
I'm referencing the original issue from another repo here: neos/neos-ui#2247 to see where the idea originated.

I added a feature behind a flag called `snap` which _when enabled_ slightly alters the way the `increase` and `decrease` methods of `TimeView` work.
The flag is optional and completely backwards compatible so there are no breaking changes.

### Motivation and Context
<!--
  * Why do you think this pull request should be merged?
  * Does it solve a problem, in that case what problem?
  * If these changes fixes an open issue, please provide a link to the issue here
-->
When the user uses the `today` button he sets the time to _now_ which, for example, could be `00:12`. 
With `step` for `minutes` set to `5` the `increase` or `decrease` buttons on minutes it will step to `17` or `7` respectively.
With `snap` enabled it will _snap_ to the next _plausible_ value depending on `step`, e.g. `15` and `10` respectively.

### Checklist
<!--
  The purpose of this checklist is for you to not forget changes you most likely should do. Look 
  through the following points, and put an "x" in all the boxes that apply. If you're unsure about 
  any of these points, then we'd recommend you to read the README. If something still is unclear 
  then don't hesitate to ask. We're here to help!
-->
```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[x] I have added tests covering my changes
[x] All new and existing tests pass
[x] My changes required the documentation to be updated
  [x] I have updated the documentation accordingly
  [x] I have updated the TypeScript 1.8 type definitions accordingly
  [x] I have updated the TypeScript 2.0+ type definitions accordingly
```


<!--
  Is there anything in this template you think is confusing, unclear, redundant or just simply bad?
  Please let us know either via creating an issue or creating a PR with changes to it.
-->
